### PR TITLE
Initial Elements API Check-in

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,11 +8,15 @@ require (
 	github.com/CycloneDX/cyclonedx-go v0.7.1
 	github.com/onesbom/onesbom v0.0.0-20230531045741-b772339fa7cf
 	github.com/sirupsen/logrus v1.9.2
+	github.com/stretchr/testify v1.8.4
 )
 
 require github.com/anchore/go-struct-converter v0.0.0-20221118182256-c68fdcfa2092 // indirect
 
 require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spdx/tools-golang v0.5.2
 	golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,7 @@ golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8T
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.30.0 h1:kPPoIgf3TsEvrm0PFe15JQ+570QVxYzEvvHqChK+cng=
 google.golang.org/protobuf v1.30.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/sbom/document.go
+++ b/pkg/sbom/document.go
@@ -1,0 +1,10 @@
+package sbom
+
+// ToNodeList returns a nodelist containing the information in the document
+func (d *Document) ToNodeList() *NodeList {
+	return &NodeList{
+		Nodes:        d.Nodes,
+		Edges:        d.Edges,
+		RootElements: d.RootElements,
+	}
+}

--- a/pkg/sbom/document.go
+++ b/pkg/sbom/document.go
@@ -8,3 +8,22 @@ func (d *Document) ToNodeList() *NodeList {
 		RootElements: d.RootElements,
 	}
 }
+
+// GetRootNodes returns a list of pointers of the root nodes of the document
+func (d *Document) GetRootNodes() []*Node {
+	ret := []*Node{}
+	index := rootElementsIndex{}
+	for _, id := range d.RootElements {
+		index[id] = struct{}{}
+	}
+	for i := range d.Nodes {
+		if _, ok := index[d.Nodes[i].Id]; ok {
+			ret = append(ret, d.Nodes[i])
+			if len(ret) == len(index) {
+				break
+			}
+		}
+	}
+	// TODO(ehandling): What if not all nodes were found?
+	return ret
+}

--- a/pkg/sbom/document_test.go
+++ b/pkg/sbom/document_test.go
@@ -1,0 +1,44 @@
+package sbom
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetRootNodes(t *testing.T) {
+	for _, tc := range []struct {
+		sut      *Document
+		expected []*Node
+	}{
+		// ID and node type should never change
+		{
+			sut: &Document{
+				Metadata:     &Metadata{},
+				RootElements: []string{"node1", "node3"},
+				Nodes: []*Node{
+					{Id: "node1"}, {Id: "node2"}, {Id: "node3"},
+				},
+				Edges: []*Edge{},
+			},
+
+			expected: []*Node{{Id: "node1"}, {Id: "node3"}},
+		},
+		// Missing nodes are not returned
+		{
+			sut: &Document{
+				Metadata:     &Metadata{},
+				RootElements: []string{"node1", "node3"},
+				Nodes: []*Node{
+					{Id: "node1"}, {Id: "node2"},
+				},
+				Edges: []*Edge{},
+			},
+
+			expected: []*Node{{Id: "node1"}},
+		},
+	} {
+		nodes := tc.sut.GetRootNodes()
+		require.Equal(t, tc.expected, nodes)
+	}
+}

--- a/pkg/sbom/edge.go
+++ b/pkg/sbom/edge.go
@@ -1,5 +1,25 @@
 package sbom
 
+// Copy returns a new edge with copies of all edges
+func (e *Edge) Copy() *Edge {
+	return &Edge{
+		Type: e.Type,
+		From: e.From,
+		To:   e.To,
+	}
+}
+
+// PointsTo returns true if an edge points to a node, in other words if it has
+// id in its list of Tos
+func (e *Edge) PointsTo(id string) bool {
+	for _, lid := range e.To {
+		if lid == id {
+			return true
+		}
+	}
+	return false
+}
+
 // ToSPDX2 converts the edge type to the corresponding SDPX2 label
 func (et Edge_Type) ToSPDX2() string {
 	switch et {

--- a/pkg/sbom/node.go
+++ b/pkg/sbom/node.go
@@ -1,0 +1,160 @@
+package sbom
+
+// This file contains methods to work with the generated node type
+// updates to the node proto should also be reflected in most of these
+// functions as they operate on the Node's fields
+
+// Update updates a node's fields with information from the second node
+// Any fields in n2 which are not null (empty string, lists longer than 0 or not nill
+// pointers will overwrite fields in Node n.
+func (n *Node) Update(n2 *Node) {
+	if n2.Name != "" {
+		n.Name = n2.Name
+	}
+	if n2.Version != "" {
+		n.Version = n2.Version
+	}
+	if n2.FileName != "" {
+		n.FileName = n2.FileName
+	}
+	if n2.UrlHome != "" {
+		n.UrlHome = n2.UrlHome
+	}
+	if n2.UrlDownload != "" {
+		n.UrlDownload = n2.UrlDownload
+	}
+	if len(n2.Licenses) > 0 {
+		n.Licenses = n2.Licenses
+	}
+	if n2.LicenseConcluded != "" {
+		n.LicenseConcluded = n2.LicenseConcluded
+	}
+	if n2.LicenseComments != "" {
+		n.LicenseComments = n2.LicenseComments
+	}
+	if n2.Copyright != "" {
+		n.Copyright = n2.Copyright
+	}
+	if len(n2.Hashes) > 0 {
+		n.Hashes = n2.Hashes
+	}
+	if n2.SourceInfo != "" {
+		n.SourceInfo = n2.SourceInfo
+	}
+	if n2.PrimaryPurpose != "" {
+		n.PrimaryPurpose = n2.PrimaryPurpose
+	}
+	if n2.Comment != "" {
+		n.Comment = n2.Comment
+	}
+	if n2.Summary != "" {
+		n.Summary = n2.Summary
+	}
+	if n2.Description != "" {
+		n.Description = n2.Description
+	}
+	if len(n2.Attribution) > 0 {
+		n.Attribution = n2.Attribution
+	}
+	if len(n2.Suppliers) > 0 {
+		n.Suppliers = n2.Suppliers
+	}
+	if len(n2.Originators) > 0 {
+		n.Originators = n2.Originators
+	}
+	if n2.ReleaseDate != nil {
+		n.ReleaseDate = n2.ReleaseDate
+	}
+	if n2.BuildDate != nil {
+		n.BuildDate = n2.BuildDate
+	}
+	if n2.ValidUntilDate != nil {
+		n.ValidUntilDate = n2.ValidUntilDate
+	}
+	if len(n2.ExternalReferences) > 0 {
+		n.ExternalReferences = n2.ExternalReferences
+	}
+	if len(n2.Identifiers) > 0 {
+		n.Identifiers = n2.Identifiers
+	}
+	if len(n2.FileTypes) > 0 {
+		n.FileTypes = n2.FileTypes
+	}
+}
+
+// Augment takes updates fields in n with data from n2 which is not already defined
+// (not empty string, not 0 length string, not nill pointer).
+func (n *Node) Augment(n2 *Node) {
+	if n.Name == "" && n2.Name != "" {
+		n.Name = n2.Name
+	}
+	if n.Version == "" && n2.Version != "" {
+		n.Version = n2.Version
+	}
+	if n.FileName == "" && n2.FileName != "" {
+		n.FileName = n2.FileName
+	}
+	if n.UrlHome == "" && n2.UrlHome != "" {
+		n.UrlHome = n2.UrlHome
+	}
+	if n.UrlDownload == "" && n2.UrlDownload != "" {
+		n.UrlDownload = n2.UrlDownload
+	}
+	if len(n.Licenses) == 0 && len(n2.Licenses) > 0 {
+		n.Licenses = n2.Licenses
+	}
+	if n.LicenseConcluded == "" && n2.LicenseConcluded != "" {
+		n.LicenseConcluded = n2.LicenseConcluded
+	}
+	if n.LicenseComments == "" && n2.LicenseComments != "" {
+		n.LicenseComments = n2.LicenseComments
+	}
+	if n.Copyright == "" && n2.Copyright != "" {
+		n.Copyright = n2.Copyright
+	}
+	if len(n.Hashes) == 0 && len(n2.Hashes) > 0 {
+		n.Hashes = n2.Hashes
+	}
+	if n.SourceInfo == "" && n2.SourceInfo != "" {
+		n.SourceInfo = n2.SourceInfo
+	}
+	if n.PrimaryPurpose == "" && n2.PrimaryPurpose != "" {
+		n.PrimaryPurpose = n2.PrimaryPurpose
+	}
+	if n.Comment == "" && n2.Comment != "" {
+		n.Comment = n2.Comment
+	}
+	if n.Summary == "" && n2.Summary != "" {
+		n.Summary = n2.Summary
+	}
+	if n.Description == "" && n2.Description != "" {
+		n.Description = n2.Description
+	}
+	if len(n.Attribution) == 0 && len(n2.Attribution) > 0 {
+		n.Attribution = n2.Attribution
+	}
+	if len(n.Suppliers) == 0 && len(n2.Suppliers) > 0 {
+		n.Suppliers = n2.Suppliers
+	}
+	if len(n.Originators) == 0 && len(n2.Originators) > 0 {
+		n.Originators = n2.Originators
+	}
+	if n.ReleaseDate == nil && n2.ReleaseDate != nil {
+		n.ReleaseDate = n2.ReleaseDate
+	}
+	if n.BuildDate == nil && n2.BuildDate != nil {
+		n.BuildDate = n2.BuildDate
+	}
+	if n.ValidUntilDate == nil && n2.ValidUntilDate != nil {
+		n.ValidUntilDate = n2.ValidUntilDate
+	}
+	if len(n.ExternalReferences) == 0 && len(n2.ExternalReferences) > 0 {
+		n.ExternalReferences = n2.ExternalReferences
+	}
+	if len(n.Identifiers) == 0 && len(n2.Identifiers) > 0 {
+		n.Identifiers = n2.Identifiers
+	}
+	if len(n.FileTypes) == 0 && len(n2.FileTypes) > 0 {
+		n.FileTypes = n2.FileTypes
+	}
+}

--- a/pkg/sbom/node.go
+++ b/pkg/sbom/node.go
@@ -158,3 +158,35 @@ func (n *Node) Augment(n2 *Node) {
 		n.FileTypes = n2.FileTypes
 	}
 }
+
+// Copy returns a new node that is a copy of the node
+func (n *Node) Copy() *Node {
+	return &Node{
+		Id:                 n.Id,
+		Type:               n.Type,
+		Name:               n.Name,
+		Version:            n.Version,
+		FileName:           n.FileName,
+		UrlHome:            n.UrlHome,
+		UrlDownload:        n.UrlDownload,
+		Licenses:           n.Licenses,
+		LicenseConcluded:   n.LicenseConcluded,
+		LicenseComments:    n.LicenseComments,
+		Copyright:          n.Copyright,
+		Hashes:             n.Hashes,
+		SourceInfo:         n.SourceInfo,
+		PrimaryPurpose:     n.PrimaryPurpose,
+		Comment:            n.Comment,
+		Summary:            n.Summary,
+		Description:        n.Description,
+		Attribution:        n.Attribution,
+		Suppliers:          n.Suppliers,
+		Originators:        n.Originators,
+		ReleaseDate:        n.ReleaseDate,
+		BuildDate:          n.BuildDate,
+		ValidUntilDate:     n.ValidUntilDate,
+		ExternalReferences: n.ExternalReferences,
+		Identifiers:        n.Identifiers,
+		FileTypes:          n.FileTypes,
+	}
+}

--- a/pkg/sbom/node_test.go
+++ b/pkg/sbom/node_test.go
@@ -1,0 +1,153 @@
+package sbom
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TestAugment(t *testing.T) {
+	fullnode := &Node{
+		Name:             "test1",
+		Version:          "1.0.0",
+		FileName:         "file.txt",
+		UrlHome:          "http://home.com/",
+		UrlDownload:      "http://home.com/file.tgz",
+		Licenses:         []string{"Apache-2.0"},
+		LicenseConcluded: "Apache-2.0",
+		LicenseComments:  "A license",
+		Copyright:        "Copyright 2023 The BOM Squad",
+		Hashes:           map[string]string{"sha1": "9283475928734987"},
+		SourceInfo:       "Source info here",
+		PrimaryPurpose:   "FILE",
+		Comment:          "Hello world",
+		Summary:          "This is a test package",
+		Description:      "This is a test package, it is red",
+		Attribution:      []string{"The BOM Squad"},
+		Suppliers: []*Person{
+			{
+				Name:  "John Doe",
+				Email: "john@doe.com",
+			},
+		},
+		Originators: []*Person{
+			{
+				Name:  "John Doe",
+				Email: "john@doe.com",
+			},
+		},
+		ReleaseDate:    timestamppb.Now(),
+		BuildDate:      timestamppb.Now(),
+		ValidUntilDate: timestamppb.Now(),
+		ExternalReferences: []*ExternalReference{
+			{
+				Url:  "git+https://github.com/example/example",
+				Type: "VCS",
+			},
+		},
+		Identifiers: []*Identifier{
+			{
+				Type:  "pkg:/apk/wolfi/glibc@12.0.0",
+				Value: "purl",
+			},
+		},
+		FileTypes: []string{"TEXT"},
+	}
+
+	for _, tc := range []struct {
+		sut      *Node
+		n2       *Node
+		expected *Node
+	}{
+		// ID and node type should never change
+		{
+			sut: &Node{
+				Id:   "test1",
+				Type: 0,
+			},
+			n2: &Node{
+				Id:   "test2",
+				Type: 1,
+			},
+			expected: &Node{
+				Id:   "test1",
+				Type: 0,
+			},
+		},
+		{
+			sut: fullnode,
+			n2: &Node{
+				Name:        "other name",
+				Version:     "2.0.0",
+				Attribution: []string{"Other attribution"},
+			},
+			expected: fullnode,
+		},
+	} {
+		tc.sut.Augment(tc.n2)
+		require.Equal(t, tc.sut, tc.expected)
+	}
+}
+
+func TestUpdate(t *testing.T) {
+	now := timestamppb.Now()
+	for _, tc := range []struct {
+		sut      *Node
+		n2       *Node
+		expected *Node
+	}{
+		// ID and node type should never change
+		{
+			sut: &Node{
+				Id:   "test1",
+				Type: 0,
+			},
+			n2: &Node{
+				Id:   "test2",
+				Type: 1,
+			},
+			expected: &Node{
+				Id:   "test1",
+				Type: 0,
+			},
+		},
+		{
+			sut: &Node{
+				Name:    "My Awesome Software",
+				Version: "1.0.0",
+				Hashes: map[string]string{
+					"SHA1": "9782347892345789234578",
+				},
+				ReleaseDate: now,
+			},
+			n2: &Node{
+				Identifiers: []*Identifier{
+					{
+						Type:  "purl",
+						Value: "pkg:generic/mysoftware@1.0.0",
+					},
+				},
+				BuildDate: now,
+			},
+			expected: &Node{
+				Name:    "My Awesome Software",
+				Version: "1.0.0",
+				Hashes: map[string]string{
+					"SHA1": "9782347892345789234578",
+				},
+				ReleaseDate: now,
+				Identifiers: []*Identifier{
+					{
+						Type:  "purl",
+						Value: "pkg:generic/mysoftware@1.0.0",
+					},
+				},
+				BuildDate: now,
+			},
+		},
+	} {
+		tc.sut.Update(tc.n2)
+		require.Equal(t, tc.sut, tc.expected)
+	}
+}

--- a/pkg/sbom/nodelist.go
+++ b/pkg/sbom/nodelist.go
@@ -18,18 +18,54 @@ func (nl *NodeList) indexIdentifiers() nodeIdList {
 // cleanEdges is a utility function that removes broken
 // connection and orphaned edges
 func (nl *NodeList) cleanEdges() {
+	// First copy the nodelist edges
+	newEdges := []*Edge{}
+
+	// Build a catalog of the elements ids
+	idDict := map[string]struct{}{}
+	for i := range nl.Nodes {
+		idDict[nl.Nodes[i].Id] = struct{}{}
+	}
+
+	// Now list all edges and rebuild the list
+	for _, edge := range nl.Edges {
+		newTos := []string{}
+		if _, ok := idDict[edge.From]; !ok {
+			continue
+		}
+
+		for _, s := range edge.To {
+			if _, ok := idDict[s]; ok {
+				newTos = append(newTos, s)
+			}
+		}
+
+		if len(newTos) == 0 {
+			continue
+		}
+
+		edge.To = newTos
+		newEdges = append(newEdges, edge)
+	}
+
+	nl.Edges = newEdges
+}
+
+// Add combines NodeList nl2 into nl. It is te equivalent to Union but
+// instead of retuirn a new NodeList modifies nl
+func (nl *NodeList) Add(nl2 *NodeList) {
 }
 
 // RemoveNodes removes a list of nodes and its edges from the nodelist
-func (nl *NodeList) RemoveNodes(...*Node) {
+func (nl *NodeList) RemoveNodes(nodes ...*Node) {
 }
 
-// Intersect returns a new NodeList with nodes which are common in nl and nl2
+// Intersect returns a new NodeList with nodes which are common in nl and nl2.
 func (nl *NodeList) Intersect(nl2 *NodeList) *NodeList {
-
+	return nil
 }
 
 // Union returns a new NodeList with all nodes from nl and nl2 joined together
 func (nl *NodeList) Union(nl2 *NodeList) *NodeList {
-
+	return nil
 }

--- a/pkg/sbom/nodelist.go
+++ b/pkg/sbom/nodelist.go
@@ -1,0 +1,35 @@
+package sbom
+
+// This file adds a few methods to the NodeList type which
+// handles fragments of the SBOM graph.
+
+// nodeIdList is an iverse dictionary to hold node identifiers
+type nodeIdList map[string]struct{}
+
+// indexIdentifiers returns an inverse dictionary with the IDs of thenodes
+func (nl *NodeList) indexIdentifiers() nodeIdList {
+	ret := nodeIdList{}
+	for i := range nl.Nodes {
+		ret[nl.Nodes[i].Id] = struct{}{}
+	}
+	return ret
+}
+
+// cleanEdges is a utility function that removes broken
+// connection and orphaned edges
+func (nl *NodeList) cleanEdges() {
+}
+
+// RemoveNodes removes a list of nodes and its edges from the nodelist
+func (nl *NodeList) RemoveNodes(...*Node) {
+}
+
+// Intersect returns a new NodeList with nodes which are common in nl and nl2
+func (nl *NodeList) Intersect(nl2 *NodeList) *NodeList {
+
+}
+
+// Union returns a new NodeList with all nodes from nl and nl2 joined together
+func (nl *NodeList) Union(nl2 *NodeList) *NodeList {
+
+}

--- a/pkg/sbom/nodelist.go
+++ b/pkg/sbom/nodelist.go
@@ -291,3 +291,45 @@ func (nl *NodeList) Union(nl2 *NodeList) *NodeList {
 
 	return ret
 }
+
+// GetNodesByName returns a list of node pointers whose name equals name
+func (nl *NodeList) GetNodesByName(name string) []*Node {
+	ret := []*Node{}
+	for i := range nl.Nodes {
+		if nl.Nodes[i].Name == name {
+			ret = append(ret, nl.Nodes[i])
+		}
+	}
+	return ret
+}
+
+// GetNodeByID returns a node with the specified ID
+func (nl *NodeList) GetNodeByID(id string) *Node {
+	for i := range nl.Nodes {
+		if nl.Nodes[i].Id == id {
+			return nl.Nodes[i]
+		}
+	}
+
+	return nil
+}
+
+// GetNodesByIdentifier returns nodes that match an identifier of type t and
+// value v, for example t = "purl" v = "pkg:deb/debian/libpam-modules@1.4.0-9+deb11u1?arch=i386"
+// Not that this only does "dumb" string matching no assumptions are made on the
+// identifer type.
+func (nl *NodeList) GetNodesByIdentifier(t, v string) []*Node {
+	ret := []*Node{}
+	for i := range nl.Nodes {
+		if nl.Nodes[i].Identifiers == nil {
+			continue
+		}
+
+		for j := range nl.Nodes[i].Identifiers {
+			if nl.Nodes[i].Identifiers[j].Type == t && nl.Nodes[i].Identifiers[j].Value == v {
+				ret = append(ret, nl.Nodes[i])
+			}
+		}
+	}
+	return ret
+}

--- a/pkg/sbom/nodelist.go
+++ b/pkg/sbom/nodelist.go
@@ -57,7 +57,22 @@ func (nl *NodeList) Add(nl2 *NodeList) {
 }
 
 // RemoveNodes removes a list of nodes and its edges from the nodelist
-func (nl *NodeList) RemoveNodes(nodes ...*Node) {
+func (nl *NodeList) RemoveNodes(ids []string) {
+	// build an inverse dict of the IDs
+	idDict := map[string]struct{}{}
+	for _, i := range ids {
+		idDict[i] = struct{}{}
+	}
+
+	newNodeList := []*Node{}
+	for i := range nl.Nodes {
+		if _, ok := idDict[nl.Nodes[i].Id]; !ok {
+			newNodeList = append(newNodeList, nl.Nodes[i])
+		}
+	}
+
+	nl.Nodes = newNodeList
+	nl.cleanEdges()
 }
 
 // Intersect returns a new NodeList with nodes which are common in nl and nl2.

--- a/pkg/sbom/nodelist_test.go
+++ b/pkg/sbom/nodelist_test.go
@@ -183,7 +183,7 @@ func TestAdd(t *testing.T) {
 	}
 }
 
-func TestIntersect(t *testing.T) {
+func TestNodeListIntersect(t *testing.T) {
 	testNodeList := &NodeList{
 		Nodes: []*Node{
 			{
@@ -280,5 +280,116 @@ func TestIntersect(t *testing.T) {
 		new := tc.sut.Intersect(tc.isec)
 		require.Equal(t, tc.expect, new, title)
 	}
+}
 
+func TestNodeListUnion(t *testing.T) {
+	testNodeList := &NodeList{
+		Nodes: []*Node{
+			{
+				Id:      "node1",
+				Type:    Node_PACKAGE,
+				Name:    "package1",
+				Version: "1.0.0",
+			},
+
+			{
+				Id:      "node2",
+				Type:    Node_PACKAGE,
+				Name:    "package1",
+				Version: "1.0.0",
+			},
+			{
+				Id:      "node3",
+				Type:    Node_PACKAGE,
+				Name:    "package1",
+				Version: "1.0.0",
+			},
+		},
+		Edges: []*Edge{
+			{
+				Type: Edge_contains,
+				From: "node1",
+				To:   []string{"node2"},
+			},
+			{
+				Type: Edge_contains,
+				From: "node1",
+				To:   []string{"node3"},
+			},
+		},
+		RootElements: []string{},
+	}
+
+	testNodeList2 := &NodeList{
+		Nodes: []*Node{
+			{
+				Id:      "node1",
+				Type:    Node_PACKAGE,
+				Name:    "package2",
+				Version: "2.0.0",
+			},
+			{
+				Id:      "node2",
+				Type:    Node_PACKAGE,
+				Name:    "package1",
+				Version: "1.0.0",
+			},
+		},
+		Edges:        []*Edge{},
+		RootElements: []string{},
+	}
+
+	for title, tc := range map[string]struct {
+		sut    *NodeList
+		isec   *NodeList
+		expect *NodeList
+	}{
+		"same nodelist unioned on itself, returns same nodelist": {
+			sut:    testNodeList,
+			isec:   testNodeList,
+			expect: testNodeList,
+		},
+		"combined nodes": {
+			sut:  testNodeList,
+			isec: testNodeList2,
+			expect: &NodeList{
+				Nodes: []*Node{
+					{
+						Id:      "node1",
+						Type:    Node_PACKAGE,
+						Name:    "package2",
+						Version: "2.0.0",
+					},
+					{
+						Id:      "node2",
+						Type:    Node_PACKAGE,
+						Name:    "package1",
+						Version: "1.0.0",
+					},
+					{
+						Id:      "node3",
+						Type:    Node_PACKAGE,
+						Name:    "package1",
+						Version: "1.0.0",
+					},
+				},
+				Edges: []*Edge{
+					{
+						Type: Edge_contains,
+						From: "node1",
+						To:   []string{"node2"},
+					},
+					{
+						Type: Edge_contains,
+						From: "node1",
+						To:   []string{"node3"},
+					},
+				},
+				RootElements: []string{},
+			},
+		},
+	} {
+		new := tc.sut.Union(tc.isec)
+		require.Equal(t, tc.expect, new, title)
+	}
 }

--- a/pkg/sbom/nodelist_test.go
+++ b/pkg/sbom/nodelist_test.go
@@ -411,3 +411,128 @@ func TestNodeListUnion(t *testing.T) {
 		require.Equal(t, tc.expect, new, title)
 	}
 }
+
+func TestGetNodesByName(t *testing.T) {
+	for _, tc := range []struct {
+		sut      *NodeList
+		name     string
+		expected []*Node
+	}{
+		{
+			&NodeList{
+				Nodes: []*Node{
+					{Id: "node1", Name: "apache-tomcat"}, {Id: "node2", Name: "apache"},
+				},
+				Edges:        []*Edge{},
+				RootElements: []string{},
+			},
+			"apache",
+			[]*Node{
+				{Id: "node2", Name: "apache"},
+			},
+		},
+		{
+			&NodeList{
+				Nodes: []*Node{
+					{Id: "nginx-arm64", Name: "nginx"}, {Id: "nginx-arm64", Name: "nginx"},
+					{Id: "nginx-libs", Name: "nginx-libs"}, {Id: "nginx-docs", Name: "nginx-docs"},
+				},
+				Edges:        []*Edge{},
+				RootElements: []string{},
+			},
+			"nginx",
+			[]*Node{
+				{Id: "nginx-arm64", Name: "nginx"}, {Id: "nginx-arm64", Name: "nginx"},
+			},
+		},
+	} {
+		res := tc.sut.GetNodesByName(tc.name)
+		require.Equal(t, tc.expected, res)
+	}
+}
+
+func TestGetNodeByID(t *testing.T) {
+	for _, tc := range []struct {
+		sut      *NodeList
+		id       string
+		expected *Node
+	}{
+		{
+			&NodeList{
+				Nodes: []*Node{
+					{Id: "node1", Name: "apache-tomcat"}, {Id: "node2", Name: "apache"},
+				},
+				Edges:        []*Edge{},
+				RootElements: []string{},
+			},
+			"node2",
+			&Node{Id: "node2", Name: "apache"},
+		},
+		{
+			&NodeList{
+				Nodes: []*Node{
+					{Id: "nginx-arm64", Name: "nginx"}, {Id: "nginx-arm64", Name: "nginx"},
+					{Id: "nginx-libs", Name: "nginx-libs"}, {Id: "nginx-docs", Name: "nginx-docs"},
+				},
+				Edges:        []*Edge{},
+				RootElements: []string{},
+			},
+			"nginx-libs",
+			&Node{Id: "nginx-libs", Name: "nginx-libs"},
+		},
+	} {
+		res := tc.sut.GetNodeByID(tc.id)
+		require.Equal(t, tc.expected, res)
+	}
+}
+
+func TestGetNodesByIdentifier(t *testing.T) {
+	for _, tc := range []struct {
+		sut        *NodeList
+		identifier *Identifier
+		expected   []*Node
+	}{
+		{
+			&NodeList{
+				Nodes: []*Node{
+					{Id: "node1", Name: "apache-tomcat", Identifiers: []*Identifier{
+						{Type: "purl", Value: "pkg:/apk/wolfi/bash@4.0.1"},
+					}},
+					{Id: "node2", Name: "apache"},
+				},
+				Edges:        []*Edge{},
+				RootElements: []string{},
+			},
+			&Identifier{Type: "purl", Value: "pkg:/apk/wolfi/bash@4.0.1"},
+			[]*Node{{Id: "node1", Name: "apache-tomcat", Identifiers: []*Identifier{
+				{Type: "purl", Value: "pkg:/apk/wolfi/bash@4.0.1"},
+			}}},
+		},
+		{
+			&NodeList{
+				Nodes: []*Node{
+					{Id: "nginx-arm64", Name: "nginx"},
+					{Id: "nginx-arm64", Name: "nginx", Identifiers: []*Identifier{
+						{Type: "purl", Value: "pkg:/apk/wolfi/nginx@1.21.1"},
+						{Type: "cpe", Value: "cpe:2.3:a:nginx:nginx:1.21.1:*:*:*:*:*:*:*"},
+					}},
+					{Id: "bash-4", Name: "bash", Identifiers: []*Identifier{
+						{Type: "purl", Value: "pkg:/apk/wolfi/bash@4.0.1"},
+						{Type: "cpe", Value: "cpe:2.3:a:bash:bash:5.0-4:*:*:*:*:*:*:*"},
+					}},
+					{Id: "nginx-docs", Name: "nginx-docs"},
+				},
+				Edges:        []*Edge{},
+				RootElements: []string{},
+			},
+			&Identifier{Type: "cpe", Value: "cpe:2.3:a:nginx:nginx:1.21.1:*:*:*:*:*:*:*"},
+			[]*Node{{Id: "nginx-arm64", Name: "nginx", Identifiers: []*Identifier{
+				{Type: "purl", Value: "pkg:/apk/wolfi/nginx@1.21.1"},
+				{Type: "cpe", Value: "cpe:2.3:a:nginx:nginx:1.21.1:*:*:*:*:*:*:*"},
+			}}},
+		},
+	} {
+		res := tc.sut.GetNodesByIdentifier(tc.identifier.Type, tc.identifier.Value)
+		require.Equal(t, tc.expected, res)
+	}
+}

--- a/pkg/sbom/nodelist_test.go
+++ b/pkg/sbom/nodelist_test.go
@@ -1,0 +1,80 @@
+package sbom
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCleanEdges(t *testing.T) {
+	for _, tc := range []struct {
+		sut      *NodeList
+		expected *NodeList
+	}{
+		// Edge does not need to be modified
+		{
+			sut: &NodeList{
+				Nodes: []*Node{
+					{Id: "node1"}, {Id: "node2"},
+				},
+				Edges: []*Edge{
+					{Type: 0, From: "node1", To: []string{"node2"}},
+				},
+				RootElements: []string{"node1"},
+			},
+
+			expected: &NodeList{
+				Nodes: []*Node{
+					{Id: "node1"}, {Id: "node2"},
+				},
+				Edges: []*Edge{
+					{Type: 0, From: "node1", To: []string{"node2"}},
+				},
+				RootElements: []string{"node1"},
+			},
+		},
+		// Edge contains a broken To
+		{
+			sut: &NodeList{
+				Nodes: []*Node{
+					{Id: "node1"}, {Id: "node2"},
+				},
+				Edges: []*Edge{
+					{Type: 0, From: "node1", To: []string{"node2", "node3"}},
+				},
+				RootElements: []string{"node1"},
+			},
+			expected: &NodeList{
+				Nodes: []*Node{
+					{Id: "node1"}, {Id: "node2"},
+				},
+				Edges: []*Edge{
+					{Type: 0, From: "node1", To: []string{"node2"}},
+				},
+				RootElements: []string{"node1"},
+			},
+		},
+		// Edge contains a broken From
+		{
+			sut: &NodeList{
+				Nodes: []*Node{
+					{Id: "node1"}, {Id: "node2"},
+				},
+				Edges: []*Edge{
+					{Type: 0, From: "node3", To: []string{"node1"}},
+				},
+				RootElements: []string{"node1"},
+			},
+			expected: &NodeList{
+				Nodes: []*Node{
+					{Id: "node1"}, {Id: "node2"},
+				},
+				Edges:        []*Edge{},
+				RootElements: []string{"node1"},
+			},
+		},
+	} {
+		tc.sut.cleanEdges()
+		require.Equal(t, tc.sut, tc.expected)
+	}
+}

--- a/pkg/sbom/nodelist_test.go
+++ b/pkg/sbom/nodelist_test.go
@@ -116,3 +116,69 @@ func TestRemoveNodes(t *testing.T) {
 		require.Equal(t, tc.sut, tc.expected)
 	}
 }
+
+func TestAdd(t *testing.T) {
+	for _, tc := range []struct {
+		sut     *NodeList
+		prepare func(*NodeList)
+		expect  *NodeList
+	}{
+		// Adding an empty nodelist is effectively as noop
+		{
+			sut: &NodeList{
+				Nodes: []*Node{
+					{Id: "test1"},
+					{Id: "test2"},
+				},
+				Edges: []*Edge{
+					{From: "test1", Type: Edge_contains, To: []string{"test2"}},
+				},
+			},
+			prepare: func(n *NodeList) {
+				n.Add(&NodeList{})
+			},
+			expect: &NodeList{
+				Nodes: []*Node{
+					{Id: "test1"},
+					{Id: "test2"},
+				},
+				Edges: []*Edge{
+					{From: "test1", Type: Edge_contains, To: []string{"test2"}},
+				},
+			},
+		},
+		// Add one node, no relationship
+		{
+			sut: &NodeList{
+				Nodes: []*Node{
+					{Id: "test1"},
+					{Id: "test2"},
+				},
+				Edges: []*Edge{
+					{From: "test1", Type: Edge_contains, To: []string{"test2"}},
+				},
+			},
+			prepare: func(n *NodeList) {
+				n.Add(&NodeList{
+					Nodes: []*Node{
+						{Id: "test3"},
+					},
+					Edges: []*Edge{},
+				})
+			},
+			expect: &NodeList{
+				Nodes: []*Node{
+					{Id: "test1"},
+					{Id: "test2"},
+					{Id: "test3"},
+				},
+				Edges: []*Edge{
+					{From: "test1", Type: Edge_contains, To: []string{"test2"}},
+				},
+			},
+		},
+	} {
+		tc.prepare(tc.sut)
+		require.Equal(t, tc.sut, tc.expect)
+	}
+}

--- a/pkg/sbom/nodelist_test.go
+++ b/pkg/sbom/nodelist_test.go
@@ -73,6 +73,29 @@ func TestCleanEdges(t *testing.T) {
 				RootElements: []string{"node1"},
 			},
 		},
+		// Duplicated edges should be consolidated
+		{
+			sut: &NodeList{
+				Nodes: []*Node{
+					{Id: "node1"}, {Id: "node2"}, {Id: "node3"},
+				},
+				Edges: []*Edge{
+					{Type: Edge_contains, From: "node1", To: []string{"node2"}},
+					{Type: Edge_contains, From: "node1", To: []string{"node3"}},
+				},
+				RootElements: []string{"node1"},
+			},
+
+			expected: &NodeList{
+				Nodes: []*Node{
+					{Id: "node1"}, {Id: "node2"}, {Id: "node3"},
+				},
+				Edges: []*Edge{
+					{Type: Edge_contains, From: "node1", To: []string{"node2", "node3"}},
+				},
+				RootElements: []string{"node1"},
+			},
+		},
 	} {
 		tc.sut.cleanEdges()
 		require.Equal(t, tc.sut, tc.expected)
@@ -210,12 +233,7 @@ func TestNodeListIntersect(t *testing.T) {
 			{
 				Type: Edge_contains,
 				From: "node1",
-				To:   []string{"node2"},
-			},
-			{
-				Type: Edge_contains,
-				From: "node1",
-				To:   []string{"node3"},
+				To:   []string{"node2", "node3"},
 			},
 		},
 		RootElements: []string{},
@@ -309,10 +327,10 @@ func TestNodeListUnion(t *testing.T) {
 			{
 				Type: Edge_contains,
 				From: "node1",
-				To:   []string{"node2"},
+				To:   []string{"node2", "node3"},
 			},
 			{
-				Type: Edge_contains,
+				Type: Edge_dependsOn,
 				From: "node1",
 				To:   []string{"node3"},
 			},
@@ -377,10 +395,10 @@ func TestNodeListUnion(t *testing.T) {
 					{
 						Type: Edge_contains,
 						From: "node1",
-						To:   []string{"node2"},
+						To:   []string{"node2", "node3"},
 					},
 					{
-						Type: Edge_contains,
+						Type: Edge_dependsOn,
 						From: "node1",
 						To:   []string{"node3"},
 					},

--- a/pkg/sbom/nodelist_test.go
+++ b/pkg/sbom/nodelist_test.go
@@ -78,3 +78,41 @@ func TestCleanEdges(t *testing.T) {
 		require.Equal(t, tc.sut, tc.expected)
 	}
 }
+
+func TestRemoveNodes(t *testing.T) {
+	for _, tc := range []struct {
+		sut      *NodeList
+		prep     func(*NodeList)
+		expected *NodeList
+	}{
+		{
+			// Two related edges. Remove the second
+			sut: &NodeList{
+				Nodes: []*Node{
+					{Id: "node1"}, {Id: "node2"},
+				},
+				Edges: []*Edge{
+					{
+						Type: 0,
+						From: "node1",
+						To:   []string{"node2"},
+					},
+				},
+				RootElements: []string{"node1"},
+			},
+			prep: func(nl *NodeList) {
+				nl.RemoveNodes([]string{"node2"})
+			},
+			expected: &NodeList{
+				Nodes: []*Node{
+					{Id: "node1"},
+				},
+				Edges:        []*Edge{},
+				RootElements: []string{"node1"},
+			},
+		},
+	} {
+		tc.prep(tc.sut)
+		require.Equal(t, tc.sut, tc.expected)
+	}
+}

--- a/pkg/sbom/nodelist_test.go
+++ b/pkg/sbom/nodelist_test.go
@@ -182,3 +182,103 @@ func TestAdd(t *testing.T) {
 		require.Equal(t, tc.sut, tc.expect)
 	}
 }
+
+func TestIntersect(t *testing.T) {
+	testNodeList := &NodeList{
+		Nodes: []*Node{
+			{
+				Id:      "node1",
+				Type:    Node_PACKAGE,
+				Name:    "package1",
+				Version: "1.0.0",
+			},
+
+			{
+				Id:      "node2",
+				Type:    Node_PACKAGE,
+				Name:    "package1",
+				Version: "1.0.0",
+			},
+			{
+				Id:      "node3",
+				Type:    Node_PACKAGE,
+				Name:    "package1",
+				Version: "1.0.0",
+			},
+		},
+		Edges: []*Edge{
+			{
+				Type: Edge_contains,
+				From: "node1",
+				To:   []string{"node2"},
+			},
+			{
+				Type: Edge_contains,
+				From: "node1",
+				To:   []string{"node3"},
+			},
+		},
+		RootElements: []string{},
+	}
+
+	testNodeList2 := &NodeList{
+		Nodes: []*Node{
+			{
+				Id:      "node1",
+				Type:    Node_PACKAGE,
+				Name:    "package2",
+				Version: "2.0.0",
+			},
+			{
+				Id:      "node2",
+				Type:    Node_PACKAGE,
+				Name:    "package1",
+				Version: "1.0.0",
+			},
+		},
+		Edges:        []*Edge{},
+		RootElements: []string{},
+	}
+
+	for title, tc := range map[string]struct {
+		sut    *NodeList
+		isec   *NodeList
+		expect *NodeList
+	}{
+		"same nodelist intersected, returns same nodelist": {
+			sut:    testNodeList,
+			isec:   testNodeList,
+			expect: testNodeList,
+		},
+		"combined nodes": {
+			sut:  testNodeList,
+			isec: testNodeList2,
+			expect: &NodeList{
+				Nodes: []*Node{
+					{
+						Id:      "node1",
+						Type:    Node_PACKAGE,
+						Name:    "package2",
+						Version: "2.0.0",
+					},
+					{
+						Id:      "node2",
+						Type:    Node_PACKAGE,
+						Name:    "package1",
+						Version: "1.0.0",
+					},
+				},
+				Edges: []*Edge{{
+					Type: Edge_contains,
+					From: "node1",
+					To:   []string{"node2"},
+				}},
+				RootElements: []string{},
+			},
+		},
+	} {
+		new := tc.sut.Intersect(tc.isec)
+		require.Equal(t, tc.expect, new, title)
+	}
+
+}


### PR DESCRIPTION
This PR adds the first batch of API functions around the objects autogenerated from the proto.

All of these functions are not yet in use in the current reader/writer flows we are developing. The goal of this API is to make it easier to work with these objects from applications that use `protobom` as a library. In other words, this PR should not affect the translation logic we are building, it only supercharges the autogenerated objects to make them easier to use.

I wrote simple tests for most functions, I will add more test cases as the API moves forward.

### API Functions

The initial API functions include:

| Object | Method | Description |
| --- | --- | --- |
| Edge | Copy() | Deep copies an Edge object |
| Edge | PointsTo() | Returns a bool if an edge points to an element  |
| Node | Copy() | Deep copies a Node object |
| Node | Augment() | Agregates data to a node's fields from another node |
| Node | Update() | Updates a node's fields from another node |
| NodeList | Add() | Adds nodes from a second NodeList |
| NodeList | RemoveNodes() | Removes nodes from a NodeList |
| NodeList | GetEdgeByType() | Returns a pointer to an edge that matches From + Type  |
| NodeList | Intersect() | Returns a new NodeList combining the elements common to two NodeLists |
| NodeList | Union() | Returns a new NodeList combining all elements of two NodeLists |

Additionally the internal API adds the following functions to the NodeList object:

| Method | Description |
| --- | --- |
| indexNodes() | returns an index of all nodes, keyed by ID |
| indexEdges | returns and index of all edges, keyed by from and type | 
| indexRootElements | returns an index of all root elements | 
| cleanEdges | Cleans the edges of an element removing broken and empty edges, deduping them , etc |


