### PR TITLE
Add testing in CI

### DIFF
--- a/.github/workflows/go-build-and-test.yml
+++ b/.github/workflows/go-build-and-test.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
 
     - name: Set up Go
       uses: actions/setup-go@v3

--- a/.github/workflows/go-build-and-test.yml
+++ b/.github/workflows/go-build-and-test.yml
@@ -9,15 +9,17 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-
     - name: Set up Go
       uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
       with:
         go-version: 1.20
         
-    - name: Get dependencies
-      run: go get -d ./...
+    - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+      with:
+        fetch-depth: 1
+        path: go/src/github.com/bom-squad/protobom
 
     - name: Test
-      run: go test -v ./...
+      run: |
+        go get -d ./...
+        go test -v ./...

--- a/.github/workflows/go-build-and-test.yml
+++ b/.github/workflows/go-build-and-test.yml
@@ -15,6 +15,9 @@ jobs:
       uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
       with:
         go-version: 1.20
+        
+    - name: Get dependencies
+      run: go get -d ./...
 
     - name: Test
       run: go test -v ./...

--- a/.github/workflows/go-build-and-test.yml
+++ b/.github/workflows/go-build-and-test.yml
@@ -15,10 +15,6 @@ jobs:
       uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
       with:
         go-version: '1.20'
-        
-    - name: build
-      run: |
-        go build ./...
 
     - name: Test
       run: |

--- a/.github/workflows/go-build-and-test.yml
+++ b/.github/workflows/go-build-and-test.yml
@@ -21,7 +21,7 @@ jobs:
 
     - name: Test
       env:
-        GOPATH: /home/runner/work/woodpecker/go
+        GOPATH: /home/runner/work/bom-squad/protobom
       run: |
         go get -d ./...
         go test -v ./...

--- a/.github/workflows/go-build-and-test.yml
+++ b/.github/workflows/go-build-and-test.yml
@@ -20,6 +20,8 @@ jobs:
         path: go/src/github.com/bom-squad/protobom
 
     - name: Test
+      env:
+        GOPATH: /home/runner/work/woodpecker/go
       run: |
         go get -d ./...
         go test -v ./...

--- a/.github/workflows/go-build-and-test.yml
+++ b/.github/workflows/go-build-and-test.yml
@@ -9,15 +9,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+
     - name: Set up Go
       uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
       with:
         go-version: 1.20
-        
-    - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-      with:
-        fetch-depth: 1
-        path: go/src/github.com/bom-squad/protobom
 
     - name: Test
       env:

--- a/.github/workflows/go-build-and-test.yml
+++ b/.github/workflows/go-build-and-test.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
       with:
-        go-version: 1.20
+        go-version: '1.20'
         
     - name: build
       run: |

--- a/.github/workflows/go-build-and-test.yml
+++ b/.github/workflows/go-build-and-test.yml
@@ -16,8 +16,5 @@ jobs:
       with:
         go-version: 1.20
 
-    - name: Build
-      run: go build -v ./...
-
     - name: Test
       run: go test -v ./...

--- a/.github/workflows/go-build-and-test.yml
+++ b/.github/workflows/go-build-and-test.yml
@@ -1,0 +1,25 @@
+name: build-and-test
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: 1.19
+
+    - name: Build
+      run: go build -v ./...
+
+    - name: Test
+      run: go test -v ./...

--- a/.github/workflows/go-build-and-test.yml
+++ b/.github/workflows/go-build-and-test.yml
@@ -17,8 +17,6 @@ jobs:
         go-version: 1.20
 
     - name: Test
-      env:
-        GOPATH: /home/runner/work/bom-squad/protobom
       run: |
         go get -d ./...
         go test -v ./...

--- a/.github/workflows/go-build-and-test.yml
+++ b/.github/workflows/go-build-and-test.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
 
     - name: Set up Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
       with:
         go-version: 1.19
 

--- a/.github/workflows/go-build-and-test.yml
+++ b/.github/workflows/go-build-and-test.yml
@@ -15,6 +15,10 @@ jobs:
       uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
       with:
         go-version: 1.20
+        
+    - name: build
+      run: |
+        go build ./...
 
     - name: Test
       run: |

--- a/.github/workflows/go-build-and-test.yml
+++ b/.github/workflows/go-build-and-test.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
       with:
-        go-version: 1.19
+        go-version: 1.20
 
     - name: Build
       run: go build -v ./...

--- a/.github/workflows/go-build-and-test.yml
+++ b/.github/workflows/go-build-and-test.yml
@@ -1,8 +1,6 @@
 name: build-and-test
 
 on:
-  push:
-    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
 


### PR DESCRIPTION
Fix #15
 
Add testing in GitHub Actions CI. It both builds and tests `protobom`. Test coverage is low. But that can be fixed in other PRs.