### PR TITLE
Add Equals Methods, deflake sbom.TestNodeListIntersect

### DIFF
--- a/pkg/sbom/edge.go
+++ b/pkg/sbom/edge.go
@@ -228,7 +228,7 @@ func (e *Edge) Equal(e2 *Edge) bool {
 }
 
 // flatString returns the edge serialized into a string that can be used
-// to indes or compare the contents of Edge e
+// to index or compare the contents of Edge e
 func (e *Edge) flatString() string {
 	return e.From + ":" + e.Type.String() + ":" + strings.Join(e.To, ":")
 }

--- a/pkg/sbom/edge.go
+++ b/pkg/sbom/edge.go
@@ -219,6 +219,14 @@ func EdgeTypeFromSPDX2(spdx2Type string) Edge_Type {
 	}
 }
 
+// Equal compares Edge e to e2 and returns true if they are the same
+func (e *Edge) Equal(e2 *Edge) bool {
+	if e2 == nil {
+		return false
+	}
+	return e.flatString() == e2.flatString()
+}
+
 // flatString returns the edge serialized into a string that can be used
 // to indes or compare the contents of Edge e
 func (e *Edge) flatString() string {

--- a/pkg/sbom/edge.go
+++ b/pkg/sbom/edge.go
@@ -218,3 +218,9 @@ func EdgeTypeFromSPDX2(spdx2Type string) Edge_Type {
 		return Edge_UNKNOWN
 	}
 }
+
+// flatString returns the edge serialized into a string that can be used
+// to indes or compare the contents of Edge e
+func (e *Edge) flatString() string {
+	return e.From + ":" + e.Type.String() + ":" + strings.Join(e.To, ":")
+}

--- a/pkg/sbom/node.go
+++ b/pkg/sbom/node.go
@@ -1,5 +1,12 @@
 package sbom
 
+import (
+	"sort"
+	"strings"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+)
+
 // This file contains methods to work with the generated node type
 // updates to the node proto should also be reflected in most of these
 // functions as they operate on the Node's fields
@@ -189,4 +196,15 @@ func (n *Node) Copy() *Node {
 		Identifiers:        n.Identifiers,
 		FileTypes:          n.FileTypes,
 	}
+}
+
+func (n *Node) flatString() string {
+	pairs := []string{}
+	n.ProtoReflect().Range(func(fd protoreflect.FieldDescriptor, v protoreflect.Value) bool {
+		pairs = append(pairs, string(fd.FullName())+":"+v.String())
+		return true
+	})
+
+	sort.Strings(pairs)
+	return strings.Join(pairs, ":")
 }

--- a/pkg/sbom/node.go
+++ b/pkg/sbom/node.go
@@ -198,6 +198,16 @@ func (n *Node) Copy() *Node {
 	}
 }
 
+// Equal compares Node n to n2 and returns true if they are the same
+func (n *Node) Equal(n2 *Node) bool {
+	if n2 == nil {
+		return false
+	}
+	return n.flatString() == n2.flatString()
+}
+
+// flatString returns a string representation of the node which can be used to
+// index the node or compare it against another
 func (n *Node) flatString() string {
 	pairs := []string{}
 	n.ProtoReflect().Range(func(fd protoreflect.FieldDescriptor, v protoreflect.Value) bool {

--- a/pkg/sbom/nodelist_test.go
+++ b/pkg/sbom/nodelist_test.go
@@ -1,6 +1,7 @@
 package sbom
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -296,7 +297,7 @@ func TestNodeListIntersect(t *testing.T) {
 		},
 	} {
 		new := tc.sut.Intersect(tc.isec)
-		require.Equal(t, tc.expect, new, title)
+		require.True(t, tc.expect.Equal(new), fmt.Sprintf("%s: %v %v", title, tc.expect, new))
 	}
 }
 


### PR DESCRIPTION
This PR adds an `Equal()` method to the `Edge`, `Node` and `NodeList` objects that lets users of the protobom API compare two objects to each other to find out if their data is the same:

```go
if node1.Equal(node2) {
   fmt.Println("Nodes are the same!")
}
```

It does so by adding an internal `flatString()` method to the objects that serializes their data into a comparable string.

As a drive-by, I've rewritten the the `sbom.TestNodeListIntersect` to use the new method from the nodelist effectively deflaking it.

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@chainguard.dev>