### PR TITLE
golangci linter followup

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,181 @@
+---
+run:
+  concurrency: 6
+  deadline: 5m
+issues:
+  exclude-rules:
+    # counterfeiter fakes are usually named 'fake_<something>.go'
+    - path: fake_.*\.go
+      linters:
+        - gocritic
+        - golint
+        - dupl
+
+  # Maximum issues count per one linter. Set to 0 to disable. Default is 50.
+  max-issues-per-linter: 0
+
+  # Maximum count of issues with the same text. Set to 0 to disable. Default is 3.
+  max-same-issues: 0
+linters:
+  disable-all: true
+  enable:
+    - asciicheck
+    - bodyclose
+    # - depguard
+    - dogsled
+    - dupl
+    - durationcheck
+    - errcheck
+    # - goconst Disabled temporarily as we need to const away all the relationships
+    - gocritic
+    # - gocyclo Disables until some functions areoptimized
+    - godox
+    - gofmt
+    - gofumpt
+    - goheader
+    - goimports
+    - gomoddirectives
+    - gomodguard
+    - goprintffuncname
+    - gosec
+    - gosimple
+    - govet
+    - importas
+    - ineffassign
+    - makezero
+    - misspell
+    - nakedret
+    - nolintlint
+    - prealloc
+    - predeclared
+    - promlinter
+    # - revive Disabled for now as we have lots of uppercase consts
+    - staticcheck
+    #- stylecheck 
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - whitespace
+    # - cyclop
+    # - errorlint
+    # - exhaustive
+    # - exhaustivestruct
+    # - exportloopref
+    # - forbidigo
+    # - forcetypeassert
+    # - funlen
+    # - gci
+    # - gochecknoglobals
+    # - gochecknoinits
+    # - gocognit
+    # - godot
+    # - goerr113
+    # - gomnd
+    # - ifshort
+    # - lll
+    # - nestif
+    # - nilerr
+    # - nlreturn
+    # - noctx
+    # - paralleltest
+    # - scopelint
+    # - tagliatelle
+    # - testpackage
+    # - thelper
+    # - tparallel
+    # - wastedassign
+    # - wrapcheck
+    # - wsl
+linters-settings:
+  godox:
+    keywords:
+      - BUG
+      - FIXME
+      - HACK
+  errcheck:
+    check-type-assertions: true
+    check-blank: true
+  gocritic:
+    enabled-checks:
+      # Diagnostic
+      - appendAssign
+      - argOrder
+      - badCond
+      - caseOrder
+      - codegenComment
+      - commentedOutCode
+      - deprecatedComment
+      - dupArg
+      - dupBranchBody
+      - dupCase
+      - dupSubExpr
+      - exitAfterDefer
+      - flagDeref
+      - flagName
+      - nilValReturn
+      - offBy1
+      - sloppyReassign
+      - weakCond
+      - octalLiteral
+
+      # Performance
+      - appendCombine
+      - equalFold
+      - hugeParam
+      - indexAlloc
+      - rangeExprCopy
+      - rangeValCopy
+
+      # Style
+      - assignOp
+      - boolExprSimplify
+      - captLocal
+      - commentFormatting
+      - commentedOutImport
+      - defaultCaseOrder
+      - docStub
+      - elseif
+      - emptyFallthrough
+      - emptyStringTest
+      - hexLiteral
+      - methodExprCall
+      - regexpMust
+      - singleCaseSwitch
+      - sloppyLen
+      - stringXbytes
+      - switchTrue
+      - typeAssertChain
+      - typeSwitchVar
+      - underef
+      - unlabelStmt
+      - unlambda
+      - unslice
+      - valSwap
+      - wrapperFunc
+      - yodaStyleExpr
+      # - ifElseChain
+
+      # Opinionated
+      - builtinShadow
+      - importShadow
+      - initClause
+      - nestingReduce
+      - paramTypeCombine
+      - ptrToRefParam
+      - typeUnparen
+      - unnamedResult
+      - unnecessaryBlock
+  nolintlint:
+    # Enable to ensure that nolint directives are all used. Default is true.
+    allow-unused: false
+    # Disable to ensure that nolint directives don't have a leading space. Default is true.
+    # TODO(lint): Enforce machine-readable `nolint` directives
+    allow-leading-space: true
+    # Exclude following linters from requiring an explanation.  Default is [].
+    allow-no-explanation: []
+    # Enable to require an explanation of nonzero length after each nolint directive. Default is false.
+    # TODO(lint): Enforce explanations for `nolint` directives
+    require-explanation: false
+    # Enable to require nolint directives to mention the specific linter being suppressed. Default is false.
+    require-specific: true

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -28,7 +28,7 @@ linters:
     - errcheck
     # - goconst Disabled temporarily as we need to const away all the relationships
     - gocritic
-    # - gocyclo Disables until some functions areoptimized
+    # - gocyclo Disables until some functions are optimized
     - godox
     - gofmt
     - gofumpt

--- a/cmd/cli/root.go
+++ b/cmd/cli/root.go
@@ -1,3 +1,5 @@
+//go:build !codeanalysis
+
 package cli
 
 import (
@@ -66,9 +68,9 @@ var RootCmd = &cobra.Command{
 func init() {
 	cobra.OnInitialize()
 
-	RootCmd.PersistentFlags().StringVarP(&Cfg.Writer.Type, "format", "f", string(options.Default.Format.Type()), fmt.Sprintf("Select format, Options=%s", writeroptions.Versions.Formats()))
+	RootCmd.PersistentFlags().StringVarP(&Cfg.Writer.Type, "format", "f", options.Default.Format.Type(), fmt.Sprintf("Select format, Options=%s", writeroptions.Versions.Formats()))
 	RootCmd.PersistentFlags().StringVarP(&Cfg.Writer.Version, "version", "v", options.Default.Format.Version(), fmt.Sprintf("Select version, Options=%s", writeroptions.Versions.VersionMap()))
-	RootCmd.PersistentFlags().StringVarP(&Cfg.Writer.Encoding, "encoding", "e", string(options.Default.Format.Encoding()), fmt.Sprintf("Select encoding, Options=%s", writeroptions.Versions.EncodingMap()))
+	RootCmd.PersistentFlags().StringVarP(&Cfg.Writer.Encoding, "encoding", "e", options.Default.Format.Encoding(), fmt.Sprintf("Select encoding, Options=%s", writeroptions.Versions.EncodingMap()))
 }
 
 func Execute() {

--- a/internal/writer/options.go
+++ b/internal/writer/options.go
@@ -1,3 +1,5 @@
+//go:build !codeanalysis
+
 package writer
 
 import (
@@ -106,8 +108,8 @@ func (v VersionGroups) EncodingMap() map[string][]string {
 	return m
 }
 
-func (v VersionGroups) URI(Type string) string {
-	return v[Type].URI
+func (v VersionGroups) URI(t string) string {
+	return v[t].URI
 }
 
 func (v VersionGroups) VersionMap() map[string][]string {

--- a/internal/writer/options.go
+++ b/internal/writer/options.go
@@ -122,7 +122,7 @@ func (v VersionGroups) VersionMap() map[string][]string {
 }
 
 func (v VersionGroups) Formats() []string {
-	var keys []string
+	keys := []string{}
 	for k := range v {
 		keys = append(keys, k)
 	}

--- a/pkg/formats/formats.go
+++ b/pkg/formats/formats.go
@@ -25,8 +25,10 @@ const (
 
 type Document interface{}
 
-var ListFormats = []Format{CDXFORMAT, SPDXFORMAT}
-var List = []Format{SPDX23TV, SPDX23JSON, SPDX22TV, SPDX22JSON, CDX14JSON, CDX15JSON}
+var (
+	ListFormats = []Format{CDXFORMAT, SPDXFORMAT}
+	List        = []Format{SPDX23TV, SPDX23JSON, SPDX22TV, SPDX22JSON, CDX14JSON, CDX15JSON}
+)
 
 // Version returns the version of the format
 func (f *Format) Version() string {

--- a/pkg/formats/spdx/spdx.go
+++ b/pkg/formats/spdx/spdx.go
@@ -6,7 +6,10 @@ package spdx
 import "strings"
 
 const (
-	NOASSERTION = "NOASSERTION"
+	NOASSERTION  = "NOASSERTION"
+	Organization = "Organization"
+	Person       = "Person"
+	Tool         = "Tool"
 )
 
 // ParseActorString parses an SPDX "actor string", it is a specially formatted
@@ -21,10 +24,10 @@ func ParseActorString(s string) (actorType, actorName, actorEmail string) {
 	s = strings.TrimSpace(s)
 	if strings.HasPrefix(s, "Person:") {
 		actorType = "person"
-		s = strings.TrimPrefix(s, "Person:")
-	} else if strings.HasPrefix(s, "Organization:") {
+		s = strings.TrimPrefix(s, Person+":")
+	} else if strings.HasPrefix(s, Organization+":") {
 		actorType = "org"
-		s = strings.TrimPrefix(s, "Organization:")
+		s = strings.TrimPrefix(s, Organization+":")
 	}
 	s = strings.TrimSpace(s)
 	actorName = s

--- a/pkg/reader/implementation.go
+++ b/pkg/reader/implementation.go
@@ -20,11 +20,11 @@ type parserImplementation interface {
 
 type defaultParserImplementation struct{}
 
-func (di *defaultParserImplementation) OpenDocumentFile(path string) (*os.File, error) {
+func (dpi *defaultParserImplementation) OpenDocumentFile(path string) (*os.File, error) {
 	return os.Open(path)
 }
 
-func (di *defaultParserImplementation) DetectFormat(opts *options.Options, r io.ReadSeeker) (formats.Format, error) {
+func (dpi *defaultParserImplementation) DetectFormat(opts *options.Options, r io.ReadSeeker) (formats.Format, error) {
 	sniffer := formats.Sniffer{}
 	format, err := sniffer.SniffReader(r)
 	if err != nil {

--- a/pkg/reader/implementation.go
+++ b/pkg/reader/implementation.go
@@ -37,8 +37,8 @@ func (dpi *defaultParserImplementation) GetUnserializer(_ *options.Options, form
 	switch string(format) {
 	case "text/spdx+json;version=2.3":
 		return &UnserializerSPDX23{}, nil
-	//case "application/vnd.cyclonedx+json;version=1.4":
-	//	return &FormatParserCDX14{}, nil
+	// case "application/vnd.cyclonedx+json;version=1.4":
+	//	 return &FormatParserCDX14{}, nil
 	default:
 		return nil, fmt.Errorf("no format parser registered for %s", format)
 	}

--- a/pkg/reader/unserializer_spdx23.go
+++ b/pkg/reader/unserializer_spdx23.go
@@ -61,7 +61,7 @@ func (u *UnserializerSPDX23) ParseStream(_ *options.Options, r io.Reader) (*sbom
 
 	for _, r := range spdxDoc.Relationships {
 		// The SPDX go library surfaces the JSON top-level elements as relationships:
-		if r.RefA.ElementRefID == "DOCUMENT" && strings.ToUpper(r.Relationship) == "DESCRIBES" {
+		if r.RefA.ElementRefID == "DOCUMENT" && strings.EqualFold(r.Relationship, "DESCRIBES") {
 			bom.NodeList.RootElements = append(bom.NodeList.RootElements, string(r.RefB.ElementRefID))
 		} else {
 			bom.NodeList.AddEdge(u.relationshipToEdge(r))

--- a/pkg/reader/unserializer_spdx23.go
+++ b/pkg/reader/unserializer_spdx23.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	protospdx "github.com/bom-squad/protobom/pkg/formats/spdx"
 	"github.com/bom-squad/protobom/pkg/reader/options"
 	"github.com/bom-squad/protobom/pkg/sbom"
 	"github.com/sirupsen/logrus"
@@ -43,7 +44,7 @@ func (u *UnserializerSPDX23) ParseStream(_ *options.Options, r io.Reader) (*sbom
 				continue
 			}
 			a := &sbom.Person{Name: c.Creator}
-			a.IsOrg = (c.CreatorType == "Organization")
+			a.IsOrg = (c.CreatorType == protospdx.Organization)
 			bom.Metadata.Authors = append(bom.Metadata.Authors, a)
 		}
 	}
@@ -92,7 +93,7 @@ func (u *UnserializerSPDX23) packageToNode(p *spdx23.Package) *sbom.Node {
 	}
 
 	// TODO(degradation) NOASSERTION
-	if p.PackageLicenseConcluded != "NOASSERTION" && p.PackageLicenseConcluded != "" {
+	if p.PackageLicenseConcluded != protospdx.NOASSERTION && p.PackageLicenseConcluded != "" {
 		n.LicenseConcluded = p.PackageLicenseConcluded
 	}
 
@@ -127,16 +128,16 @@ func (u *UnserializerSPDX23) packageToNode(p *spdx23.Package) *sbom.Node {
 	// Mmh there is a limitation here on the SPDX libraries. They will not
 	// return the supplier and originator emails as a separate field. Perhaps
 	// we should upstream a fix for that.
-	if p.PackageSupplier != nil && p.PackageSupplier.Supplier != "NOASSERTION" {
+	if p.PackageSupplier != nil && p.PackageSupplier.Supplier != protospdx.NOASSERTION {
 		n.Suppliers = []*sbom.Person{{Name: p.PackageSupplier.Supplier}}
-		if p.PackageSupplier.SupplierType == "Organization" {
+		if p.PackageSupplier.SupplierType == protospdx.Organization {
 			n.Suppliers[0].IsOrg = true
 		}
 	}
 
-	if p.PackageOriginator != nil && p.PackageOriginator.Originator != "NOASSERTION" && p.PackageOriginator.Originator != "" {
+	if p.PackageOriginator != nil && p.PackageOriginator.Originator != protospdx.NOASSERTION && p.PackageOriginator.Originator != "" {
 		n.Originators = []*sbom.Person{{Name: p.PackageOriginator.Originator}}
-		if p.PackageOriginator.OriginatorType == "Organization" {
+		if p.PackageOriginator.OriginatorType == protospdx.Organization {
 			n.Originators[0].IsOrg = true
 		}
 	}

--- a/pkg/reader/unserializer_spdx23.go
+++ b/pkg/reader/unserializer_spdx23.go
@@ -146,7 +146,7 @@ func (u *UnserializerSPDX23) packageToNode(p *spdx23.Package) *sbom.Node {
 }
 
 // spdxDateToTime is a utility function that turns a date into a go time.Time
-func (_ *UnserializerSPDX23) spdxDateToTime(date string) *time.Time {
+func (*UnserializerSPDX23) spdxDateToTime(date string) *time.Time {
 	if date == "" {
 		return nil
 	}
@@ -159,7 +159,7 @@ func (_ *UnserializerSPDX23) spdxDateToTime(date string) *time.Time {
 }
 
 // fileToNode converts a file from SPDX into a protobom node
-func (fp *UnserializerSPDX23) fileToNode(f *spdx23.File) *sbom.Node {
+func (u *UnserializerSPDX23) fileToNode(f *spdx23.File) *sbom.Node {
 	n := &sbom.Node{
 		Id:               string(f.FileSPDXIdentifier),
 		Type:             sbom.Node_FILE,
@@ -186,7 +186,7 @@ func (fp *UnserializerSPDX23) fileToNode(f *spdx23.File) *sbom.Node {
 }
 
 // relationshipToEdge converts the SPDX relationship to a protobom Edge
-func (_ *UnserializerSPDX23) relationshipToEdge(r *spdx23.Relationship) *sbom.Edge {
+func (*UnserializerSPDX23) relationshipToEdge(r *spdx23.Relationship) *sbom.Edge {
 	// TODO(degradation) How to handle external documents?
 	// TODO(degradation) How to handle NOASSERTION and NONE targets
 	e := &sbom.Edge{

--- a/pkg/sbom/document.go
+++ b/pkg/sbom/document.go
@@ -18,8 +18,8 @@ func NewDocument() *Document {
 	}
 }
 
-// GetRootNodes returns the top level nodes of the document
+// GetRootNodes returns the top level nodes of the document. It calls the underlying
+// method in the document's NodeList.
 func (d *Document) GetRootNodes() []*Node {
-	// TODO: Implement me
-	return d.GetRootNodes() //nolint:staticcheck
+	return d.NodeList.GetRootNodes()
 }

--- a/pkg/sbom/functions.go
+++ b/pkg/sbom/functions.go
@@ -25,7 +25,7 @@ var invalidIDCharsRe = regexp.MustCompile(`[^a-zA-Z0-9-.]+`)
 // come from an ingested SBOM.
 //
 // Without any strings seeding it, NewNodeIdentifier generates the identifier
-// using an UUID. If a string is provided, any invalid characters will be removed and the 
+// using an UUID. If a string is provided, any invalid characters will be removed and the
 // new string will be used as the identifier.
 func NewNodeIdentifier(prefixes ...string) string {
 	validPrefixes := []string{}

--- a/pkg/sbom/nodelist.go
+++ b/pkg/sbom/nodelist.go
@@ -188,12 +188,12 @@ func (nl *NodeList) GetEdgeByType(fromElement string, t Edge_Type) *Edge {
 }
 
 // copyEdgeList is a utility function that deep copies a list of edges
-func copyEdgeList(original []*Edge) (copy []*Edge) {
-	copy = []*Edge{}
+func copyEdgeList(original []*Edge) []*Edge {
+	nodeCopy := []*Edge{}
 	for _, e := range original {
-		copy = append(copy, e.Copy())
+		nodeCopy = append(nodeCopy, e.Copy())
 	}
-	return copy
+	return nodeCopy
 }
 
 // Intersect returns a new NodeList with nodes which are common in nl and nl2.
@@ -332,7 +332,7 @@ func (nl *NodeList) GetNodeByID(id string) *Node {
 // GetNodesByIdentifier returns nodes that match an identifier of type t and
 // value v, for example t = "purl" v = "pkg:deb/debian/libpam-modules@1.4.0-9+deb11u1?arch=i386"
 // Not that this only does "dumb" string matching no assumptions are made on the
-// identifer type.
+// identifier type.
 func (nl *NodeList) GetNodesByIdentifier(t, v string) []*Node {
 	ret := []*Node{}
 	for i := range nl.Nodes {

--- a/pkg/sbom/nodelist_test.go
+++ b/pkg/sbom/nodelist_test.go
@@ -435,8 +435,10 @@ func TestGetNodesByName(t *testing.T) {
 		{
 			&NodeList{
 				Nodes: []*Node{
-					{Id: "nginx-arm64", Name: "nginx"}, {Id: "nginx-arm64", Name: "nginx"},
-					{Id: "nginx-libs", Name: "nginx-libs"}, {Id: "nginx-docs", Name: "nginx-docs"},
+					{Id: "nginx-arm64", Name: "nginx"},
+					{Id: "nginx-arm64", Name: "nginx"},
+					{Id: "nginx-libs", Name: "nginx-libs"},
+					{Id: "nginx-docs", Name: "nginx-docs"},
 				},
 				Edges:        []*Edge{},
 				RootElements: []string{},
@@ -472,8 +474,10 @@ func TestGetNodeByID(t *testing.T) {
 		{
 			&NodeList{
 				Nodes: []*Node{
-					{Id: "nginx-arm64", Name: "nginx"}, {Id: "nginx-arm64", Name: "nginx"},
-					{Id: "nginx-libs", Name: "nginx-libs"}, {Id: "nginx-docs", Name: "nginx-docs"},
+					{Id: "nginx-arm64", Name: "nginx"},
+					{Id: "nginx-arm64", Name: "nginx"},
+					{Id: "nginx-libs", Name: "nginx-libs"},
+					{Id: "nginx-docs", Name: "nginx-docs"},
 				},
 				Edges:        []*Edge{},
 				RootElements: []string{},

--- a/pkg/sbom/nodelist_test.go
+++ b/pkg/sbom/nodelist_test.go
@@ -296,8 +296,8 @@ func TestNodeListIntersect(t *testing.T) {
 			},
 		},
 	} {
-		new := tc.sut.Intersect(tc.isec)
-		require.True(t, tc.expect.Equal(new), fmt.Sprintf("%s: %v %v", title, tc.expect, new))
+		newNodeList := tc.sut.Intersect(tc.isec)
+		require.True(t, tc.expect.Equal(newNodeList), fmt.Sprintf("%s: %v %v", title, tc.expect, newNodeList))
 	}
 }
 
@@ -408,8 +408,8 @@ func TestNodeListUnion(t *testing.T) {
 			},
 		},
 	} {
-		new := tc.sut.Union(tc.isec)
-		require.Equal(t, tc.expect, new, title)
+		newNodeList := tc.sut.Union(tc.isec)
+		require.Equal(t, tc.expect, newNodeList, title)
 	}
 }
 

--- a/pkg/writer/implementation.go
+++ b/pkg/writer/implementation.go
@@ -45,16 +45,6 @@ func (di *defaultWriterImplementation) SerializeSBOM(opts options.Options, seria
 	return nil
 }
 
-//nolint:unused
-func findNodeById(bom *sbom.Document, id string) *sbom.Node {
-	for _, n := range bom.NodeList.Nodes {
-		if n.Id == id {
-			return n
-		}
-	}
-	return nil
-}
-
 // OpenFile opens the file at path and returns it
 func (di *defaultWriterImplementation) OpenFile(path string) (*os.File, error) {
 	f, err := os.Open(path)

--- a/pkg/writer/serializer_cdx.go
+++ b/pkg/writer/serializer_cdx.go
@@ -298,7 +298,7 @@ func newSerializerCDXState() *serializerCDXState {
 }
 
 func (s *serializerCDXState) components() []cdx.Component {
-	var components []cdx.Component
+	components := []cdx.Component{}
 	for _, c := range s.componentsDict {
 		if _, ok := s.addedDict[c.BOMRef]; ok {
 			continue

--- a/pkg/writer/serializer_cdx.go
+++ b/pkg/writer/serializer_cdx.go
@@ -15,9 +15,10 @@ import (
 )
 
 const (
-	stateKey = "cyclonedx_serializer_state"
+	stateKey state = "cyclonedx_serializer_state"
 )
 
+type state string
 type SerializerCDX struct{}
 
 func (s *SerializerCDX) Serialize(opts options.Options, bom *sbom.Document) (interface{}, error) {
@@ -25,7 +26,7 @@ func (s *SerializerCDX) Serialize(opts options.Options, bom *sbom.Document) (int
 	// but we should get it as part of the method to capture cancelations
 	// from the CLI or REST API.
 	state := newSerializerCDXState()
-	ctx := context.WithValue(context.Background(), stateKey, state) //nolint
+	ctx := context.WithValue(context.Background(), stateKey, state)
 
 	doc := cdx.NewBOM()
 	doc.SerialNumber = bom.Metadata.Id
@@ -35,7 +36,7 @@ func (s *SerializerCDX) Serialize(opts options.Options, bom *sbom.Document) (int
 	}
 
 	metadata := cdx.Metadata{
-		Component: &cdx.Component{}, //nolint
+		Component: &cdx.Component{},
 	}
 
 	doc.Metadata = &metadata

--- a/pkg/writer/serializer_cdx.go
+++ b/pkg/writer/serializer_cdx.go
@@ -18,8 +18,10 @@ const (
 	stateKey state = "cyclonedx_serializer_state"
 )
 
-type state string
-type SerializerCDX struct{}
+type (
+	state         string
+	SerializerCDX struct{}
+)
 
 func (s *SerializerCDX) Serialize(opts options.Options, bom *sbom.Document) (interface{}, error) {
 	// Load the context with the CDX value. We initialize a context here
@@ -72,9 +74,9 @@ func (s *SerializerCDX) Serialize(opts options.Options, bom *sbom.Document) (int
 // to all nodes that don't have them. To maintain the closest fidelity, we
 // clear their refs again before output to CDX
 func clearAutoRefs(comps *[]cdx.Component) {
-	for i, comp := range *comps {
-		if strings.HasPrefix(comp.BOMRef, "protobom-") {
-			flags := strings.Split(comp.BOMRef, "--")
+	for i := range *comps {
+		if strings.HasPrefix((*comps)[i].BOMRef, "protobom-") {
+			flags := strings.Split((*comps)[i].BOMRef, "--")
 			if strings.Contains(flags[0], "-auto") {
 				(*comps)[i].BOMRef = ""
 			}
@@ -135,7 +137,6 @@ func (s *SerializerCDX) root(ctx context.Context, bom *sbom.Document) (*cdx.Comp
 
 // NOTE dependencies function modifies the components dictionary
 func (s *SerializerCDX) dependencies(ctx context.Context, bom *sbom.Document) ([]cdx.Dependency, error) {
-
 	var dependencies []cdx.Dependency
 	state, err := getCDXState(ctx)
 	if err != nil {
@@ -154,7 +155,7 @@ func (s *SerializerCDX) dependencies(ctx context.Context, bom *sbom.Document) ([
 
 		// In this example, we tree-ify all components related with a
 		// "contains" relationship. This is just an opinion for the demo
-		// and it is somethign we can parameterize
+		// and it is something we can parameterize
 		switch e.Type {
 		case sbom.Edge_contains:
 			// Make sure we have the target component

--- a/pkg/writer/serializer_spdx23.go
+++ b/pkg/writer/serializer_spdx23.go
@@ -88,7 +88,7 @@ func (s *SerializerSPDX23) Serialize(opts options.Options, bom *sbom.Document) (
 	return doc, nil
 }
 
-func buildRelationships(bom *sbom.Document) ([]*spdx.Relationship, error) {
+func buildRelationships(bom *sbom.Document) ([]*spdx.Relationship, error) { //nolint:unparam
 	relationships := []*spdx.Relationship{}
 	for _, e := range bom.NodeList.Edges {
 		for _, dest := range e.To {
@@ -104,7 +104,7 @@ func buildRelationships(bom *sbom.Document) ([]*spdx.Relationship, error) {
 	return relationships, nil
 }
 
-func buildFiles(bom *sbom.Document) ([]*spdx.File, error) {
+func buildFiles(bom *sbom.Document) ([]*spdx.File, error) { //nolint:unparam
 	files := []*spdx.File{}
 	for _, node := range bom.NodeList.Nodes {
 		if node.Type == sbom.Node_PACKAGE {
@@ -150,7 +150,7 @@ func buildFiles(bom *sbom.Document) ([]*spdx.File, error) {
 	return files, nil
 }
 
-func buildPackages(bom *sbom.Document) ([]*spdx.Package, error) {
+func buildPackages(bom *sbom.Document) ([]*spdx.Package, error) { //nolint:unparam
 	packages := []*spdx.Package{}
 	for _, node := range bom.NodeList.Nodes {
 		if node.Type == sbom.Node_FILE {


### PR DESCRIPTION
This is a followup to https://github.com/bom-squad/protobom/pull/33 mainly to fix a bug discovered while adding the golangci lint job to the repo and to fix some warning which were valid but were muted.

This PR also adds a config file for golangci-lint enabling a few more linters. I've fixed all the warnings caused by the new linters and I will slowly be cranking up a few more in the coming weeks (see comments in the configuration files).

/cc @jspeed-meyers 

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@chainguard.dev>