### PR TITLE
SPDX Improvenments

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,10 +10,12 @@ require (
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.7.0
 	github.com/stretchr/testify v1.8.4
+	sigs.k8s.io/release-utils v0.7.4
 )
 
 require (
 	github.com/anchore/go-struct-converter v0.0.0-20221118182256-c68fdcfa2092 // indirect
+	github.com/common-nighthawk/go-figure v0.0.0-20210622060536-734e95fb86be // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 )
@@ -22,6 +24,6 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spdx/tools-golang v0.5.2
-	golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 // indirect
+	golang.org/x/sys v0.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ github.com/CycloneDX/cyclonedx-go v0.7.1/go.mod h1:N/nrdWQI2SIjaACyyDs/u7+ddCkyl
 github.com/anchore/go-struct-converter v0.0.0-20221118182256-c68fdcfa2092 h1:aM1rlcoLz8y5B2r4tTLMiVTrMtpfY0O8EScKJxaSaEc=
 github.com/anchore/go-struct-converter v0.0.0-20221118182256-c68fdcfa2092/go.mod h1:rYqSE9HbjzpHTI74vwPvae4ZVYZd1lue2ta6xHPdblA=
 github.com/bradleyjkemp/cupaloy/v2 v2.8.0 h1:any4BmKE+jGIaMpnU8YgH/I2LPiLBufr6oMMlVBbn9M=
+github.com/common-nighthawk/go-figure v0.0.0-20210622060536-734e95fb86be h1:J5BL2kskAlV9ckgEsNQXscjIaLiOYiZ75d4e94E6dcQ=
+github.com/common-nighthawk/go-figure v0.0.0-20210622060536-734e95fb86be/go.mod h1:mk5IQ+Y0ZeO87b858TlA645sVcEcbiX6YqP98kt+7+w=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -35,8 +37,9 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 h1:0A+M6Uqn+Eje4kHMK80dtF3JCXC4ykBgQG4Fe06QRhQ=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.4.0 h1:Zr2JFtRQNX3BCZ8YtxRE9hNJYC8J6I1MVbMg6owUp18=
+golang.org/x/sys v0.4.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.31.0 h1:g0LDEJHgrBl9N9r17Ru3sqWhkIx2NB67okBHPwC7hs8=
@@ -47,4 +50,6 @@ gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+sigs.k8s.io/release-utils v0.7.4 h1:17LmJrydpUloTCtaoWj95uKlcrUp4h2A9Sa+ZL+lV9w=
+sigs.k8s.io/release-utils v0.7.4/go.mod h1:JEt2QPHItd5Pg2UKLAU8PEaSlF4bUjCZimpxFDgymVU=
 sigs.k8s.io/yaml v1.3.0/go.mod h1:GeOyir5tyXNByN85N/dRIT9es5UQNerPYEKK56eTBm8=

--- a/pkg/formats/sniffer.go
+++ b/pkg/formats/sniffer.go
@@ -85,11 +85,6 @@ func (fs *Sniffer) SniffReader(f io.ReadSeeker) (Format, error) {
 		}
 	}
 
-	fmt.Fprintf(
-		os.Stderr, "format: %s version: %s encoding: %s\n",
-		formatType, formatVersion, formatEncoding,
-	)
-
 	for _, f := range List {
 		if string(f) == fmt.Sprintf("%s+%s;version=%s", formatType, formatEncoding, formatVersion) {
 			return f, nil

--- a/pkg/formats/spdx/spdx.go
+++ b/pkg/formats/spdx/spdx.go
@@ -8,6 +8,7 @@ import "strings"
 const (
 	DOCUMENT     = "DOCUMENT"
 	NOASSERTION  = "NOASSERTION"
+	NONE         = "NONE"
 	Organization = "Organization"
 	Person       = "Person"
 	Tool         = "Tool"

--- a/pkg/formats/spdx/spdx.go
+++ b/pkg/formats/spdx/spdx.go
@@ -6,6 +6,7 @@ package spdx
 import "strings"
 
 const (
+	DOCUMENT     = "DOCUMENT"
 	NOASSERTION  = "NOASSERTION"
 	Organization = "Organization"
 	Person       = "Person"

--- a/pkg/sbom/externalreference.go
+++ b/pkg/sbom/externalreference.go
@@ -1,0 +1,22 @@
+package sbom
+
+// ToSPDX2Category returns the type of the external reference in the
+// spdx 2.x vocabulary.
+func (e *ExternalReference) ToSPDX2Category() string {
+	switch e.ToSPDX2Type() {
+	case "cpe22Type", "cpe23Type", "advisory", "fix", "url", "swid":
+		return "SECURITY"
+	case "maven-central", "npm", "nuget", "bower", "purl":
+		return "PACKAGE-MANAGER"
+	case "swh", "gitoid":
+		return "PERSISTENT-ID"
+	default:
+		return "OTHER"
+	}
+}
+
+// ToSPDX2Type converts the external reference type to the SPDX 2.x equivalent.
+func (e *ExternalReference) ToSPDX2Type() string {
+	// TODO: Shoud we be mopre prescriptive here?
+	return e.Type
+}

--- a/pkg/sbom/person.go
+++ b/pkg/sbom/person.go
@@ -1,0 +1,27 @@
+package sbom
+
+import (
+	"fmt"
+
+	"github.com/bom-squad/protobom/pkg/formats/spdx"
+)
+
+// ToSPDX2ClientString converts the person to an SPDX actor string (not valid for
+// an SBOM but to feed into the SPDX go-tools).
+func (p *Person) ToSPDX2ClientString() string {
+	supplierString := p.Name
+	if p.Email != "" {
+		supplierString = fmt.Sprintf("%s (%s)", p.Name, p.Email)
+	}
+	return supplierString
+}
+
+// ToSPDX2ClientOrg returns a string representing the type of actor to
+// use in the SPDX go-tools, basically it will returns "Organization" or "Person"
+func (p *Person) ToSPDX2ClientOrg() string {
+	if p.IsOrg {
+		return spdx.Organization
+	} else {
+		return spdx.Person
+	}
+}


### PR DESCRIPTION
This PR adds a couple of improvements to the SPDX code in protobom:

- Support for external references in the serializer
- Creator, supplier and originator 
- Record of protobom version in the document creation info

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@chainguard.dev>