### PR TITLE
Protobom API Improvements

### DIFF
--- a/pkg/sbom/edge.go
+++ b/pkg/sbom/edge.go
@@ -1,6 +1,9 @@
 package sbom
 
-import "strings"
+import (
+	"sort"
+	"strings"
+)
 
 // Copy returns a new edge with copies of all edges
 func (e *Edge) Copy() *Edge {
@@ -230,5 +233,7 @@ func (e *Edge) Equal(e2 *Edge) bool {
 // flatString returns the edge serialized into a string that can be used
 // to index or compare the contents of Edge e
 func (e *Edge) flatString() string {
-	return e.From + ":" + e.Type.String() + ":" + strings.Join(e.To, ":")
+	tos := e.To
+	sort.Strings(tos)
+	return e.From + ":" + e.Type.String() + ":" + strings.Join(tos, "+")
 }

--- a/pkg/sbom/node.go
+++ b/pkg/sbom/node.go
@@ -218,3 +218,20 @@ func (n *Node) flatString() string {
 	sort.Strings(pairs)
 	return strings.Join(pairs, ":")
 }
+
+type PackageURL string
+
+// Purl returns the node purl as a string
+func (n *Node) Purl() PackageURL {
+	if n.Type == Node_FILE {
+		return ""
+	}
+
+	for _, e := range n.ExternalReferences {
+		if e.Type == "purl" {
+			return PackageURL(e.Url)
+		}
+	}
+
+	return ""
+}

--- a/pkg/sbom/nodelist.go
+++ b/pkg/sbom/nodelist.go
@@ -102,7 +102,9 @@ func (nl *NodeList) cleanEdges() {
 		for s := range newTos[f] {
 			seenCache[f].To = append(seenCache[f].To, s)
 		}
-		newEdges = append(newEdges, seenCache[f])
+		if len(seenCache[f].To) > 0 {
+			newEdges = append(newEdges, seenCache[f])
+		}
 	}
 
 	nl.Edges = newEdges
@@ -416,7 +418,7 @@ func (nl *NodeList) Equal(nl2 *NodeList) bool {
 	}
 
 	if !reflect.DeepEqual(nlNodes, nl2Nodes) {
-		logrus.Infof("NodeList 1: %+v\nNodeList 2: %+v", nlNodes, nl2Nodes)
+		logrus.Info("No: nodes")
 		return false
 	}
 

--- a/pkg/sbom/nodelist_test.go
+++ b/pkg/sbom/nodelist_test.go
@@ -541,3 +541,35 @@ func TestGetNodesByIdentifier(t *testing.T) {
 		require.Equal(t, tc.expected, res)
 	}
 }
+
+func TestGetNodesByPurlType(t *testing.T) {
+	for _, tc := range []struct {
+		nl             *NodeList
+		query          string
+		expectedLength int
+	}{
+		{
+			nl: &NodeList{
+				Nodes: []*Node{
+					{Id: "nginx-arm64", Name: "nginx"},
+					{Id: "nginx-arm64", Name: "nginx", ExternalReferences: []*ExternalReference{
+						{Type: "purl", Url: "pkg:/apk/wolfi/nginx@1.21.1"},
+						{Type: "cpe", Url: "cpe:2.3:a:nginx:nginx:1.21.1:*:*:*:*:*:*:*"},
+					}},
+					{Id: "bash-4", Name: "bash", ExternalReferences: []*ExternalReference{
+						{Type: "purl", Url: "pkg:/apk/wolfi/bash@4.0.1"},
+						{Type: "cpe", Url: "cpe:2.3:a:bash:bash:5.0-4:*:*:*:*:*:*:*"},
+					}},
+					{Id: "nginx-docs", Name: "nginx-docs"},
+				},
+				Edges:        []*Edge{},
+				RootElements: []string{},
+			},
+			query:          "apk",
+			expectedLength: 2,
+		},
+	} {
+		res := tc.nl.GetNodesByPurlType(tc.query)
+		require.Len(t, res.Nodes, tc.expectedLength)
+	}
+}

--- a/pkg/sbom/nodelist_test.go
+++ b/pkg/sbom/nodelist_test.go
@@ -8,12 +8,11 @@ import (
 )
 
 func TestCleanEdges(t *testing.T) {
-	for _, tc := range []struct {
+	for m, tc := range map[string]struct {
 		sut      *NodeList
 		expected *NodeList
 	}{
-		// Edge does not need to be modified
-		{
+		"Edge does not need to be modified": {
 			sut: &NodeList{
 				Nodes: []*Node{
 					{Id: "node1"}, {Id: "node2"},
@@ -34,8 +33,7 @@ func TestCleanEdges(t *testing.T) {
 				RootElements: []string{"node1"},
 			},
 		},
-		// Edge contains a broken To
-		{
+		"Edge contains a broken To": {
 			sut: &NodeList{
 				Nodes: []*Node{
 					{Id: "node1"}, {Id: "node2"},
@@ -55,8 +53,7 @@ func TestCleanEdges(t *testing.T) {
 				RootElements: []string{"node1"},
 			},
 		},
-		// Edge contains a broken From
-		{
+		"Edge contains a broken From": {
 			sut: &NodeList{
 				Nodes: []*Node{
 					{Id: "node1"}, {Id: "node2"},
@@ -74,8 +71,7 @@ func TestCleanEdges(t *testing.T) {
 				RootElements: []string{"node1"},
 			},
 		},
-		// Duplicated edges should be consolidated
-		{
+		"Duplicated edges should be consolidated": {
 			sut: &NodeList{
 				Nodes: []*Node{
 					{Id: "node1"}, {Id: "node2"}, {Id: "node3"},
@@ -99,7 +95,7 @@ func TestCleanEdges(t *testing.T) {
 		},
 	} {
 		tc.sut.cleanEdges()
-		require.Equal(t, tc.sut, tc.expected)
+		require.True(t, tc.sut.Equal(tc.expected), m)
 	}
 }
 
@@ -409,7 +405,7 @@ func TestNodeListUnion(t *testing.T) {
 		},
 	} {
 		newNodeList := tc.sut.Union(tc.isec)
-		require.Equal(t, tc.expect, newNodeList, title)
+		require.True(t, tc.expect.Equal(newNodeList), title)
 	}
 }
 
@@ -539,37 +535,5 @@ func TestGetNodesByIdentifier(t *testing.T) {
 	} {
 		res := tc.sut.GetNodesByIdentifier(tc.identifier.Type, tc.identifier.Value)
 		require.Equal(t, tc.expected, res)
-	}
-}
-
-func TestGetNodesByPurlType(t *testing.T) {
-	for _, tc := range []struct {
-		nl             *NodeList
-		query          string
-		expectedLength int
-	}{
-		{
-			nl: &NodeList{
-				Nodes: []*Node{
-					{Id: "nginx-arm64", Name: "nginx"},
-					{Id: "nginx-arm64", Name: "nginx", ExternalReferences: []*ExternalReference{
-						{Type: "purl", Url: "pkg:/apk/wolfi/nginx@1.21.1"},
-						{Type: "cpe", Url: "cpe:2.3:a:nginx:nginx:1.21.1:*:*:*:*:*:*:*"},
-					}},
-					{Id: "bash-4", Name: "bash", ExternalReferences: []*ExternalReference{
-						{Type: "purl", Url: "pkg:/apk/wolfi/bash@4.0.1"},
-						{Type: "cpe", Url: "cpe:2.3:a:bash:bash:5.0-4:*:*:*:*:*:*:*"},
-					}},
-					{Id: "nginx-docs", Name: "nginx-docs"},
-				},
-				Edges:        []*Edge{},
-				RootElements: []string{},
-			},
-			query:          "apk",
-			expectedLength: 2,
-		},
-	} {
-		res := tc.nl.GetNodesByPurlType(tc.query)
-		require.Len(t, res.Nodes, tc.expectedLength)
 	}
 }


### PR DESCRIPTION
This PR introduces two new functions to the protobom API:

- nodelist.RelateNodeListAtID(): his method takes a nodelist n2 and relates its top level elements to
the a node in nodelist nl1 using an edge type.
- nodelist.GetNodesByPurlType : return all methods that match a package URL type.

It also includes a final commit to further deflake some tests that deal with checking the consistency of the graph operations.

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@chainguard.dev>