### PR TITLE
Restore identifier SPDX convenience methods

### DIFF
--- a/pkg/formats/spdx/spdx.go
+++ b/pkg/formats/spdx/spdx.go
@@ -12,6 +12,12 @@ const (
 	Organization = "Organization"
 	Person       = "Person"
 	Tool         = "Tool"
+
+	// Identifier categories
+	CategorySecurity       = "SECURITY"
+	CategoryPackageManager = "PACKAGE-MANAGER"
+	CategoryPersistentID   = "PERSISTENT-ID"
+	CategoryOther          = "OTHER"
 )
 
 // ParseActorString parses an SPDX "actor string", it is a specially formatted

--- a/pkg/sbom/externalreference.go
+++ b/pkg/sbom/externalreference.go
@@ -1,19 +1,23 @@
 package sbom
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/bom-squad/protobom/pkg/formats/spdx"
+)
 
 // ToSPDX2Category returns the type of the external reference in the
 // spdx 2.x vocabulary.
 func (e *ExternalReference) ToSPDX2Category() string {
 	switch e.ToSPDX2Type() {
 	case "cpe22Type", "cpe23Type", "advisory", "fix", "url", "swid":
-		return "SECURITY"
+		return spdx.CategorySecurity
 	case "maven-central", "npm", "nuget", "bower", "purl":
-		return "PACKAGE-MANAGER"
+		return spdx.CategoryPackageManager
 	case "swh", "gitoid":
-		return "PERSISTENT-ID"
+		return spdx.CategoryPersistentID
 	default:
-		return "OTHER"
+		return spdx.CategoryOther
 	}
 }
 
@@ -23,6 +27,7 @@ func (e *ExternalReference) ToSPDX2Type() string {
 	return e.Type
 }
 
+// flatString returns a deterministic string that can be used to hash the external reference
 func (e *ExternalReference) flatString() string {
 	ret := ""
 	if e.Type != "" {

--- a/pkg/sbom/identifier.go
+++ b/pkg/sbom/identifier.go
@@ -1,7 +1,33 @@
 package sbom
 
-import "fmt"
+import (
+	"fmt"
 
+	"github.com/bom-squad/protobom/pkg/formats/spdx"
+)
+
+// flatstring returns a deterministic string that can be used to hash the identifier
 func (i *Identifier) flatString() string {
 	return fmt.Sprintf("bomsquad.protobom.Node.identifiers[%s]:%s", i.Type, i.Value)
+}
+
+// ToSPDX2Category returns the type of the external reference in the
+// spdx 2.x vocabulary.
+func (i *Identifier) ToSPDX2Category() string {
+	switch i.ToSPDX2Type() {
+	case "cpe22", "cpe23", "advisory", "fix", "url", "swid":
+		return spdx.CategorySecurity
+	case "maven-central", "npm", "nuget", "bower", "purl":
+		return spdx.CategoryPackageManager
+	case "swh", "gitoid":
+		return spdx.CategoryPersistentID
+	default:
+		return spdx.CategoryOther
+	}
+}
+
+// ToSPDX2Type converts the external reference type to the SPDX 2.x equivalent.
+func (i *Identifier) ToSPDX2Type() string {
+	// TODO: Should we be more prescriptive here?
+	return i.Type
 }

--- a/pkg/sbom/identifier_test.go
+++ b/pkg/sbom/identifier_test.go
@@ -1,0 +1,41 @@
+package sbom
+
+import (
+	"testing"
+
+	"github.com/bom-squad/protobom/pkg/formats/spdx"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIToSPDX2Category(t *testing.T) {
+	for _, tc := range []struct {
+		sut      string
+		expected string
+	}{
+		{"cpe22", spdx.CategorySecurity},
+		{"cpe23", spdx.CategorySecurity},
+		{"advisory", spdx.CategorySecurity},
+		{"fix", spdx.CategorySecurity},
+		{"url", spdx.CategorySecurity},
+		{"swid", spdx.CategorySecurity},
+
+		{"maven-central", spdx.CategoryPackageManager},
+		{"npm", spdx.CategoryPackageManager},
+		{"nuget", spdx.CategoryPackageManager},
+		{"bower", spdx.CategoryPackageManager},
+		{"purl", spdx.CategoryPackageManager},
+
+		{"swh", spdx.CategoryPersistentID},
+		{"gitoid", spdx.CategoryPersistentID},
+
+		{"", spdx.CategoryOther},
+		{"lkjsedlfkjsldkj", spdx.CategoryOther},
+	} {
+		identifier := Identifier{
+			Type:  tc.sut,
+			Value: "does not matter",
+		}
+		cat := identifier.ToSPDX2Category()
+		require.Equal(t, tc.expected, cat)
+	}
+}


### PR DESCRIPTION
This PR restores a few methods in the protobom identifier object which either I had forgotten to commit or that I overwrote at some point by mistake.


Signed-off-by: Adolfo García Veytia (Puerco) <puerco@chainguard.dev>