### PR TITLE
docs: add devcontainer getting started

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,21 @@
+# Devlopment
+
+### Development Container
+
+1. Docker / Podman
+2. VSCode (or other supported IDE)
+3. Remote-Containers [extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
+
+### Native
+
+1. Go 1.20+
+2. Make
+
+## Getting Started
+
+First, clone this repository and make sure you have your enviornment all setup. </br>
+For support IDEs users, you can simply run this project in a container (aka devcontainer): </br>
+
+The option would be available once you install the recommended extension. </br>
+
+See more details [here](https://containers.dev/supporting)


### PR DESCRIPTION
A fundamental development getting-started doc. 

We cannot assume everybody uses VSCode so I made it more general, we can go back to it later.

Once we add `Make` commands we should update this docs as well. 


