### PR TITLE
Fix purl and CPE retrieval and storage

### DIFF
--- a/pkg/reader/unserializer_cdx14.go
+++ b/pkg/reader/unserializer_cdx14.go
@@ -130,20 +130,20 @@ func (u *UnserializerCDX14) componentToNode(c *cdx.Component) (*sbom.Node, error
 
 	// Named external references:
 	if c.CPE != "" {
-		er := &sbom.ExternalReference{
-			Url:  c.CPE,
-			Type: "cpe22",
+		ident := &sbom.Identifier{
+			Value: c.CPE,
+			Type:  "cpe22",
 		}
 		if strings.HasPrefix(c.CPE, "cpe:2.3") {
-			er.Type = "cpe23"
+			ident.Type = "cpe23"
 		}
-		node.ExternalReferences = append(node.ExternalReferences, er)
+		node.Identifiers = append(node.Identifiers, ident)
 	}
 
 	if c.PackageURL != "" {
-		node.ExternalReferences = append(node.ExternalReferences, &sbom.ExternalReference{
-			Url:  c.PackageURL,
-			Type: "purl",
+		node.Identifiers = append(node.Identifiers, &sbom.Identifier{
+			Type:  "purl",
+			Value: c.PackageURL,
 		})
 	}
 

--- a/pkg/reader/unserializer_spdx23.go
+++ b/pkg/reader/unserializer_spdx23.go
@@ -107,11 +107,25 @@ func (u *UnserializerSPDX23) packageToNode(p *spdx23.Package) *sbom.Node {
 	if len(p.PackageExternalReferences) > 0 {
 		n.ExternalReferences = []*sbom.ExternalReference{}
 		for _, r := range p.PackageExternalReferences {
-			n.ExternalReferences = append(n.ExternalReferences, &sbom.ExternalReference{
-				Url:     r.Locator,
-				Type:    r.RefType,
-				Comment: r.ExternalRefComment,
-			})
+			switch r.RefType {
+			case "purl", "cpe22Type", "cpe23Type", "gitoid":
+				t := r.RefType
+				if t == "cpe22Type" {
+					t = "cpe22"
+				} else if t == "cpe23Type" {
+					t = "cpe23"
+				}
+				n.Identifiers = append(n.Identifiers, &sbom.Identifier{
+					Type:  t,
+					Value: r.Locator,
+				})
+			default:
+				n.ExternalReferences = append(n.ExternalReferences, &sbom.ExternalReference{
+					Url:     r.Locator,
+					Type:    r.RefType,
+					Comment: r.ExternalRefComment,
+				})
+			}
 		}
 	}
 

--- a/pkg/sbom/identifier.go
+++ b/pkg/sbom/identifier.go
@@ -15,7 +15,7 @@ func (i *Identifier) flatString() string {
 // spdx 2.x vocabulary.
 func (i *Identifier) ToSPDX2Category() string {
 	switch i.ToSPDX2Type() {
-	case "cpe22", "cpe23", "advisory", "fix", "url", "swid":
+	case "cpe22Type", "cpe23Type", "advisory", "fix", "url", "swid":
 		return spdx.CategorySecurity
 	case "maven-central", "npm", "nuget", "bower", "purl":
 		return spdx.CategoryPackageManager
@@ -28,6 +28,12 @@ func (i *Identifier) ToSPDX2Category() string {
 
 // ToSPDX2Type converts the external reference type to the SPDX 2.x equivalent.
 func (i *Identifier) ToSPDX2Type() string {
-	// TODO: Should we be more prescriptive here?
-	return i.Type
+	switch i.Type {
+	case "cpe22":
+		return "cpe22Type"
+	case "cpe23":
+		return "cpe23Type"
+	default:
+		return i.Type
+	}
 }

--- a/pkg/sbom/node.go
+++ b/pkg/sbom/node.go
@@ -291,9 +291,9 @@ func (n *Node) Purl() PackageURL {
 		return ""
 	}
 
-	for _, e := range n.ExternalReferences {
+	for _, e := range n.Identifiers {
 		if e.Type == "purl" {
-			return PackageURL(e.Url)
+			return PackageURL(e.Value)
 		}
 	}
 

--- a/pkg/writer/serializer_cdx.go
+++ b/pkg/writer/serializer_cdx.go
@@ -249,11 +249,6 @@ func (s *SerializerCDX) nodeToComponent(n *sbom.Node) *cdx.Component {
 
 	if n.ExternalReferences != nil {
 		for _, er := range n.ExternalReferences {
-			if er.Type == "purl" {
-				c.PackageURL = er.Url
-				continue
-			}
-
 			if c.ExternalReferences == nil {
 				c.ExternalReferences = &[]cdx.ExternalReference{}
 			}
@@ -262,6 +257,22 @@ func (s *SerializerCDX) nodeToComponent(n *sbom.Node) *cdx.Component {
 				Type: cdx.ExternalReferenceType(er.Type), // Fix to make it valid
 				URL:  er.Url,
 			})
+		}
+	}
+
+	if n.Identifiers != nil {
+		for _, ident := range n.Identifiers {
+			switch ident.Type {
+			case "purl":
+				c.PackageURL = ident.Value
+			case "cpe23":
+				c.CPE = ident.Value
+			case "cpe22":
+				// TODO(degradation): Only one CPE is supperted in CDX
+				if c.CPE == "" {
+					c.CPE = ident.Value
+				}
+			}
 		}
 	}
 

--- a/pkg/writer/serializer_spdx23.go
+++ b/pkg/writer/serializer_spdx23.go
@@ -257,6 +257,14 @@ func buildPackages(bom *sbom.Document) ([]*spdx.Package, error) { //nolint:unpar
 			})
 		}
 
+		for _, i := range node.Identifiers {
+			p.PackageExternalReferences = append(p.PackageExternalReferences, &v2_3.PackageExternalReference{
+				Category: i.ToSPDX2Category(),
+				RefType:  i.ToSPDX2Type(),
+				Locator:  i.Value,
+			})
+		}
+
 		if len(node.Suppliers) > 0 {
 			// TODO(degradation): URL, Phone are lost if set
 			// TODO(degradation): If is more than one supplier, it will be lost


### PR DESCRIPTION
This PR fixes a bug where all serializers and parsers were storing and reading the purl from the `node.ExternalReferences` list. The protobom model has a dedicated collection for software identifiers to keep them apart from the rest of the other references. This makes sure the data is being stored in the right place.

Signed-off-by: Adolfo Garcia Veytia (puerco) <puerco@chainguard.dev>