### PR TITLE
nodelist.GetMatchingNode()

### DIFF
--- a/pkg/sbom/node.go
+++ b/pkg/sbom/node.go
@@ -299,3 +299,30 @@ func (n *Node) Purl() PackageURL {
 
 	return ""
 }
+
+// HashesMatch takes a map of hashes th and returns a boolean indicating
+// if the test hashes match those of the node. The algorithm will only take
+// into account algorithms that are common to the node and test set.
+//
+// In other words, if th has any hashes in algorithms without a peer in the
+// node, the function will ignore them and return true if others match,
+// silently ignoring those missing in the node.
+//
+// If either the node or the test hashes are empty, no match is assumed.
+func (n *Node) HashesMatch(th map[string]string) bool {
+	if len(n.Hashes) == 0 || len(th) == 0 {
+		return false
+	}
+	atLeastOneMatch := false
+	for algo, hashValue := range th {
+		if _, ok := n.Hashes[algo]; !ok {
+			continue
+		}
+
+		if n.Hashes[algo] != hashValue {
+			return false
+		}
+		atLeastOneMatch = true
+	}
+	return atLeastOneMatch
+}


### PR DESCRIPTION
This PR introduces a new method called `GetMatchingNode()` to the `NodeList` object. This method looks for a node that matches the passed node:

```golang
   matchingNode, err = nodelist.GetMatchingNode(testnode)
```

A "matching node" is a node that describes the same piece of software as the test node. This function is critical because node IDs are only valid within the document, so when looking for a matching node from a second SBOM, ID-based comparison cannot be done.

The function guarantees only one matching node. If there is ambiguity and two nodes from the nodelist fit the testnode, an error is returned.

The method looks for matching nodes by comparing the hashes first and if no match is done it tries to match based on the purl of the nodes. Purl matching needs a bit more polishing but it works for identical strings.

I wrote a lengthy test, it is included in the PR.

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@chainguard.dev>