### PR TITLE
Use ReadSeeker for reader.ParseStream.

### DIFF
--- a/pkg/reader/reader.go
+++ b/pkg/reader/reader.go
@@ -38,7 +38,7 @@ func (r *Reader) ParseFile(path string) (*sbom.Document, error) {
 }
 
 // ParseStream returns a document from a io reader
-func (r *Reader) ParseStream(f io.ReadSeekCloser) (*sbom.Document, error) {
+func (r *Reader) ParseStream(f io.ReadSeeker) (*sbom.Document, error) {
 	format, err := r.impl.DetectFormat(&r.Options, f)
 	if err != nil {
 		return nil, fmt.Errorf("detecting SBOM format: %w", err)


### PR DESCRIPTION
Previously this was ReadSeekCloser, but the Close method was never used.

This also makes it easier to use with existing types like [bytes.Reader](https://pkg.go.dev/bytes#Reader), since you can now do:

```go
r := reader.New()
doc, err := r.ParseStream(bytes.NewReader(b))
```