### PR TITLE
Pluginize the load of serializers and unserializers

### DIFF
--- a/pkg/writer/serializer_cdx.go
+++ b/pkg/writer/serializer_cdx.go
@@ -179,7 +179,6 @@ func (s *SerializerCDX) dependencies(ctx context.Context, bom *sbom.Document) ([
 					return nil, fmt.Errorf("unable to locate node %s", targetID)
 				}
 
-				//nolint:gosec
 				dependencies = append(dependencies, cdx.Dependency{
 					Ref:          e.From,
 					Dependencies: &e.To,


### PR DESCRIPTION
This commit adds a simple plugin interface in the reader and writer packages to load the serializers and unserializers of the native formats.

This new registration metaphor lets applications register alternative implementations of the drivers that read and write the native SBOM formats.

This change maintains compatibility with the previous implementation, no API changes.

Related to https://github.com/bom-squad/protobom/pull/72

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@chainguard.dev>