### PR TITLE
Add writer support for Authors

### DIFF
--- a/pkg/writer/serializer_cdx.go
+++ b/pkg/writer/serializer_cdx.go
@@ -55,6 +55,19 @@ func (s *SerializerCDX) Serialize(opts options.Options, bom *sbom.Document) (int
 		return nil, err
 	}
 
+	if bom.Metadata != nil && len(bom.GetMetadata().GetAuthors()) > 0 {
+		
+		var authors []cdx.OrganizationalContact
+		for _, bomauthor := range bom.GetMetadata().GetAuthors() {
+
+			authors = append(authors, cdx.OrganizationalContact{
+				Name:  bomauthor.Name,
+				Email: bomauthor.Email,
+				Phone: bomauthor.Phone})
+		}
+		metadata.Authors = &authors
+	}
+	
 	deps, err := s.dependencies(ctx, bom)
 	if err != nil {
 		return nil, err

--- a/pkg/writer/serializer_cdx.go
+++ b/pkg/writer/serializer_cdx.go
@@ -56,18 +56,17 @@ func (s *SerializerCDX) Serialize(opts options.Options, bom *sbom.Document) (int
 	}
 
 	if bom.Metadata != nil && len(bom.GetMetadata().GetAuthors()) > 0 {
-		
 		var authors []cdx.OrganizationalContact
 		for _, bomauthor := range bom.GetMetadata().GetAuthors() {
-
 			authors = append(authors, cdx.OrganizationalContact{
 				Name:  bomauthor.Name,
 				Email: bomauthor.Email,
-				Phone: bomauthor.Phone})
+				Phone: bomauthor.Phone,
+			})
 		}
 		metadata.Authors = &authors
 	}
-	
+
 	deps, err := s.dependencies(ctx, bom)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This commit adds support for the protobom Metadata.Authors field to be written as CycloneDX Metadata.Authors field.  They are datatype cdx.OrganizationalContact:

```
	if bom.Metadata != nil && len(bom.GetMetadata().GetAuthors()) > 0 {
		var authors []cdx.OrganizationalContact
		for _, bomauthor := range bom.GetMetadata().GetAuthors() {

			authors = append(authors, cdx.OrganizationalContact{
				Name:  bomauthor.Name,
				Email: bomauthor.Email,
				Phone: bomauthor.Phone})
		}
		metadata.Authors = &authors
	}
```