### PR TITLE
ensure c.Type == file if node.Type is file

### DIFF
--- a/pkg/native/serializers/serializer_cdx.go
+++ b/pkg/native/serializers/serializer_cdx.go
@@ -279,7 +279,7 @@ func (s *SerializerCDX) nodeToComponent(n *sbom.Node) *cdx.Component {
 			// TODO(degradation): Non-matching primary purpose to component type mapping
 		}
 	}
-	
+
 	if n.Licenses != nil && len(n.Licenses) > 0 {
 		var licenseChoices []cdx.LicenseChoice
 		var licenses cdx.Licenses

--- a/pkg/native/serializers/serializer_cdx.go
+++ b/pkg/native/serializers/serializer_cdx.go
@@ -244,38 +244,42 @@ func (s *SerializerCDX) nodeToComponent(n *sbom.Node) *cdx.Component {
 		Version:     n.Version,
 		Description: n.Description,
 	}
-
-	switch strings.ToLower(n.PrimaryPurpose) {
-	case "application":
-		c.Type = cdx.ComponentTypeApplication
-	case "container":
-		c.Type = cdx.ComponentTypeContainer
-	case "data":
-		c.Type = cdx.ComponentTypeData
-	case "device":
-		c.Type = cdx.ComponentTypeDevice
-	case "device-driver":
-		c.Type = cdx.ComponentTypeDeviceDriver
-	case "file":
+	
+	if n.Type == sbom.Node_FILE {
 		c.Type = cdx.ComponentTypeFile
-	case "firmware":
-		c.Type = cdx.ComponentTypeFirmware
-	case "framework":
-		c.Type = cdx.ComponentTypeFramework
-	case "library":
-		c.Type = cdx.ComponentTypeLibrary
-	case "machine-learning-model":
-		c.Type = cdx.ComponentTypeMachineLearningModel
-	case "operating-system":
-		c.Type = cdx.ComponentTypeOS
-	case "platform":
-		c.Type = cdx.ComponentTypePlatform
-	case "":
-		// no node PrimaryPurpose set
-	default:
-		// TODO(degradation): Non-matching primary purpose to component type mapping
+	} else {
+		switch strings.ToLower(n.PrimaryPurpose) {
+		case "application":
+			c.Type = cdx.ComponentTypeApplication
+		case "container":
+			c.Type = cdx.ComponentTypeContainer
+		case "data":
+			c.Type = cdx.ComponentTypeData
+		case "device":
+			c.Type = cdx.ComponentTypeDevice
+		case "device-driver":
+			c.Type = cdx.ComponentTypeDeviceDriver
+		case "file":
+			c.Type = cdx.ComponentTypeFile
+		case "firmware":
+			c.Type = cdx.ComponentTypeFirmware
+		case "framework":
+			c.Type = cdx.ComponentTypeFramework
+		case "library":
+			c.Type = cdx.ComponentTypeLibrary
+		case "machine-learning-model":
+			c.Type = cdx.ComponentTypeMachineLearningModel
+		case "operating-system":
+			c.Type = cdx.ComponentTypeOS
+		case "platform":
+			c.Type = cdx.ComponentTypePlatform
+		case "":
+			// no node PrimaryPurpose set
+		default:
+			// TODO(degradation): Non-matching primary purpose to component type mapping
+		}
 	}
-
+	
 	if n.Licenses != nil && len(n.Licenses) > 0 {
 		var licenseChoices []cdx.LicenseChoice
 		var licenses cdx.Licenses

--- a/pkg/native/serializers/serializer_cdx.go
+++ b/pkg/native/serializers/serializer_cdx.go
@@ -244,7 +244,7 @@ func (s *SerializerCDX) nodeToComponent(n *sbom.Node) *cdx.Component {
 		Version:     n.Version,
 		Description: n.Description,
 	}
-	
+
 	if n.Type == sbom.Node_FILE {
 		c.Type = cdx.ComponentTypeFile
 	} else {


### PR DESCRIPTION
My last change in this area was actually incorrect.  if protobom node.Type is "file" then CycloneDX Type MUST be "file".  

When ingesting an SBOM, this is what is supposed to happen:
* If we ingest cdx, the component.Type value should go to the primarypurpose field
** Additionally if component.Type is "file" the node should be marked as Node_FILE
* If we ingest spdx goes from primary purpose to primary purpose
When rendering the node to native SBOM:
* If it's SPDX the value goes from primary purpose to primary purpose
* If it's CDX:
** If the node is Node_FILE component.Type is file. Nothing else should happen or the graph will break.
** All others should go from the primary purpose to component.Type

Thanks @puerco for setting me straight here.  We would have had data loss without this change.

```
	if n.Type == sbom.Node_FILE {
		c.Type = cdx.ComponentTypeFile
	} else {
		switch strings.ToLower(n.PrimaryPurpose) {
		case "application":
			c.Type = cdx.ComponentTypeApplication
		case "container":
			c.Type = cdx.ComponentTypeContainer
		case "data":
			c.Type = cdx.ComponentTypeData
                ....
```