### PR TITLE
Return error if native serializer does not return valid root node

### DIFF
--- a/pkg/native/serializers/serializer_cdx.go
+++ b/pkg/native/serializers/serializer_cdx.go
@@ -48,6 +48,8 @@ func (s *SerializerCDX) Serialize(opts options.Options, bom *sbom.Document) (int
 	rootComponent, err := s.root(ctx, bom)
 	if err != nil {
 		return nil, fmt.Errorf("generating SBOM root component: %w", err)
+	} else if rootComponent == nil {
+		return nil, fmt.Errorf("No SBOM root component")
 	}
 
 	doc.Metadata.Component = rootComponent


### PR DESCRIPTION
Fixes an issue found by fuzzing (https://github.com/bom-squad/sbom-convert/pull/13). Added check to return error if serializer root component is nil.

```
	rootComponent, err := s.root(ctx, bom)
	if err != nil {
		return nil, fmt.Errorf("generating SBOM root component: %w", err)
	} else if rootComponent == nil {
		return nil, fmt.Errorf("No SBOM root component")
	}
```

(the else if is added)