### PR TITLE
Use json.Unmarshal to get CDX specVersion (replacing string hacks)

### DIFF
--- a/pkg/formats/sniffer_test.go
+++ b/pkg/formats/sniffer_test.go
@@ -52,6 +52,13 @@ func TestSniffReader(t *testing.T) {
 			encoding:   "json",
 		},
 		{
+			filename:   "testdata/minified.cdx.json",
+			mustError:  false,
+			version:    "1.4",
+			formatType: "cyclonedx",
+			encoding:   "json",
+		},
+		{
 			filename:  "testdata/syft.json",
 			mustError: true,
 		},

--- a/pkg/formats/testdata/minified.cdx.json
+++ b/pkg/formats/testdata/minified.cdx.json
@@ -1,0 +1,1 @@
+{"bomFormat":"CycloneDX","specVersion":"1.4","version":1,"serialNumber":"urn:uuid:b35ea91e-91c2-40ae-97fe-c015a4fd8790","metadata":{}}


### PR DESCRIPTION
Attempt to read just the SpecVersion from the JSON via json.Unmarshal.  If this succeeds, use that version.  If it fails, use the string hacks in place already.

Added a test case for the minified json included in the issue.

Fixes https://github.com/bom-squad/protobom/issues/112