### PR TITLE
Capture the SPDX version and CDX version both in one shot

### DIFF
--- a/pkg/formats/sniffer.go
+++ b/pkg/formats/sniffer.go
@@ -138,7 +138,6 @@ func (st *sniffState) Format() Format {
 type cdxSniff struct{}
 
 func (c cdxSniff) sniff(data []byte) Format {
-
 	// protobom only supports CDX formats as JSON
 	//  we are parsing the JSON in SniffReader by decoding to the SpecVersionStruct
 	//   removing all the previous JSON-related string matching from this function

--- a/pkg/formats/sniffer.go
+++ b/pkg/formats/sniffer.go
@@ -86,7 +86,7 @@ func (fs *Sniffer) SniffReader(f io.ReadSeeker) (Format, error) {
 
 	_, err = f.Seek(0, 0)
 	if err != nil {
-		return fmt.Errorf("seeking to the beginning of SBOM file: %w", err)
+		return "", fmt.Errorf("seeking to the beginning of SBOM file: %w", err)
 	}
 
 	fileScanner := bufio.NewScanner(f)

--- a/pkg/formats/sniffer.go
+++ b/pkg/formats/sniffer.go
@@ -86,7 +86,7 @@ func (fs *Sniffer) SniffReader(f io.ReadSeeker) (Format, error) {
 
 	_, err = f.Seek(0, 0)
 	if err != nil {
-		fmt.Printf("WARNING: could not seek to beginning of file: %v", err)
+		return fmt.Errorf("seeking to the beginning of SBOM file: %w", err)
 	}
 
 	fileScanner := bufio.NewScanner(f)

--- a/pkg/formats/sniffer.go
+++ b/pkg/formats/sniffer.go
@@ -46,6 +46,49 @@ func (fs *Sniffer) SniffReader(f io.ReadSeeker) (Format, error) {
 			fmt.Printf("WARNING: could not seek to beginning of file: %v", err)
 		}
 	}()
+
+	type SpecVersionStruct struct {
+		BomFormat       string `json:"bomFormat"`
+		CDXSpecVersion  string `json:"specVersion"`
+		SPDXSpecVersion string `json:"spdxVersion"`
+	}
+
+	decoder := json.NewDecoder(f)
+
+	var specversionjson SpecVersionStruct
+	err := decoder.Decode(&specversionjson)
+	if err == nil {
+		if specversionjson.BomFormat == "CycloneDX" {
+			if specversionjson.CDXSpecVersion == "1.3" {
+				return CDX13JSON, nil
+			} else if specversionjson.CDXSpecVersion == "1.4" {
+				return CDX14JSON, nil
+			} else if specversionjson.CDXSpecVersion == "1.5" {
+				return CDX15JSON, nil
+			} else {
+				// JSON + BomFormat CycloneDX but specVersion not 1.3, 1.4, or 1.5
+				return "", fmt.Errorf("unknown SBOM format")
+			}
+		} else {
+			// JSON but not CycloneDX so assuming SPDX
+			if specversionjson.SPDXSpecVersion == "SPDX-2.2" {
+				return SPDX22JSON, nil
+			} else if specversionjson.SPDXSpecVersion == "SPDX-2.3" {
+				return SPDX23JSON, nil
+			} else {
+				// JSON + not CycloneDX but spdxVersion not SPDX-2.2 or SPDX-2.3
+				return "", fmt.Errorf("unknown SBOM format")
+			}
+		}
+	}
+
+	// not JSON.  Parse line-by-line with string hacks
+
+	_, err = f.Seek(0, 0)
+	if err != nil {
+		fmt.Printf("WARNING: could not seek to beginning of file: %v", err)
+	}
+
 	fileScanner := bufio.NewScanner(f)
 	fileScanner.Split(bufio.ScanLines)
 
@@ -103,27 +146,13 @@ func (c cdxSniff) sniff(data []byte) Format {
 		state.Encoding = JSON
 	}
 
-	if state.Encoding == JSON {
-		type SpecVersionStruct struct {
-			SpecVersion string `json:"specVersion"`
-		}
-
-		var specversionjson SpecVersionStruct
-		err := json.Unmarshal(data, &specversionjson)
-		if err == nil {
-			state.Version = specversionjson.SpecVersion
-		}
-	}
-
-	if state.Version == "" || state.Encoding == "" {
-		if strings.Contains(stringValue, `"specVersion"`) {
-			parts := strings.Split(stringValue, ":")
-			if len(parts) == 2 {
-				ver := strings.TrimPrefix(strings.TrimSuffix(strings.TrimSuffix(strings.TrimSpace(parts[1]), ","), "\""), "\"")
-				if ver != "" {
-					state.Version = ver
-					state.Encoding = JSON
-				}
+	if strings.Contains(stringValue, `"specVersion"`) {
+		parts := strings.Split(stringValue, ":")
+		if len(parts) == 2 {
+			ver := strings.TrimPrefix(strings.TrimSuffix(strings.TrimSuffix(strings.TrimSpace(parts[1]), ","), "\""), "\"")
+			if ver != "" {
+				state.Version = ver
+				state.Encoding = JSON
 			}
 		}
 	}

--- a/pkg/formats/sniffer.go
+++ b/pkg/formats/sniffer.go
@@ -58,7 +58,7 @@ func (fs *Sniffer) SniffReader(f io.ReadSeeker) (Format, error) {
 	var specversionjson SpecVersionStruct
 	err := decoder.Decode(&specversionjson)
 	if err == nil {
-		if strings.ToLower(specversionjson.BomFormat) == CDXFORMAT {
+		if strings.EqualFold(specversionjson.BomFormat, CDXFORMAT) {
 			if specversionjson.CDXSpecVersion == "1.3" {
 				return CDX13JSON, nil
 			} else if specversionjson.CDXSpecVersion == "1.4" {

--- a/pkg/formats/sniffer.go
+++ b/pkg/formats/sniffer.go
@@ -58,7 +58,7 @@ func (fs *Sniffer) SniffReader(f io.ReadSeeker) (Format, error) {
 	var specversionjson SpecVersionStruct
 	err := decoder.Decode(&specversionjson)
 	if err == nil {
-		if specversionjson.BomFormat == "CycloneDX" {
+		if strings.ToLower(specversionjson.BomFormat) == CDXFORMAT {
 			if specversionjson.CDXSpecVersion == "1.3" {
 				return CDX13JSON, nil
 			} else if specversionjson.CDXSpecVersion == "1.4" {


### PR DESCRIPTION
I'm proposing to revert the change I made yesterday to fix https://github.com/bom-squad/protobom/issues/112.  This implementation is better as it will capture both the SPDX and CDX versions in one shot without having to do any string hacks. Thanks for suggestion @puerco 