### PR TITLE
Small fixes following up on 102

### DIFF
--- a/pkg/native/serializers/serializer_cdx.go
+++ b/pkg/native/serializers/serializer_cdx.go
@@ -444,6 +444,10 @@ func (s *CDX) Render(doc interface{}, wr io.Writer, o *native.RenderOptions) err
 	encoder := cdx.NewBOMEncoder(wr, encoding)
 	encoder.SetPretty(true)
 
+	if _, ok := doc.(*cdx.BOM); !ok {
+		return errors.New("document is not a cyclonedx bom")
+	}
+
 	if err := encoder.EncodeVersion(doc.(*cdx.BOM), version); err != nil {
 		return fmt.Errorf("encoding sbom to stream: %w", err)
 	}

--- a/pkg/native/unserializers/unserializer_cdx.go
+++ b/pkg/native/unserializers/unserializer_cdx.go
@@ -28,8 +28,8 @@ func NewCDX(version, encoding string) *CDX {
 	}
 }
 
-// ParseStream reads a CycloneDX 1.5 from stream r usinbg the offcial CycloneDX
-// libraries and returns a protobom document with its data.
+// Unserialize reads datq data from io.Reader r and parses it as a CycloneDX
+// document. If successful returns a protobom Document loaded with the SBOM data.
 func (u *CDX) Unserialize(r io.Reader, _ *native.UnserializeOptions) (*sbom.Document, error) {
 	bom := new(cdx.BOM)
 

--- a/pkg/writer/options.go
+++ b/pkg/writer/options.go
@@ -18,7 +18,7 @@ func WithRenderOptions(ro map[string]*native.RenderOptions) WriterOption {
 func WithSerializeOptions(so map[string]*native.SerializeOptions) WriterOption {
 	return func(w *Writer) {
 		if so != nil {
-			w.SerialzeOptions = so
+			w.SerializeOptions = so
 		}
 	}
 }

--- a/pkg/writer/writer.go
+++ b/pkg/writer/writer.go
@@ -1,6 +1,7 @@
 package writer
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -27,14 +28,12 @@ var (
 		},
 	}
 	defaultSerializeOptions = &native.SerializeOptions{}
-	defaultFormat           = formats.CDX15JSON
 )
 
 func New(opts ...WriterOption) *Writer {
 	r := &Writer{
 		RenderOptions:   make(map[string]*native.RenderOptions),
 		SerialzeOptions: make(map[string]*native.SerializeOptions),
-		Format:          defaultFormat,
 	}
 
 	for _, opt := range opts {
@@ -72,13 +71,21 @@ func UnregisterSerializer(format formats.Format) {
 	regMtx.Unlock()
 }
 
+// GetFormatSerializer returns the registered serializer for a specific format. If
+// format is a blank string or no serializer for the format is registered, it will
+// return an error.
 func GetFormatSerializer(format formats.Format) (native.Serializer, error) {
+	if format == "" {
+		return nil, errors.New("unable to find serializer, no format specified")
+	}
 	if _, ok := serializers[format]; ok {
 		return serializers[format], nil
 	}
 	return nil, fmt.Errorf("no serializer registered for %s", format)
 }
 
+// WriteStreamWithOptions writes an SBOM in a native format to the stream w using
+// the options set o.
 func (w *Writer) WriteStreamWithOptions(bom *sbom.Document, wr io.WriteCloser, o *Options) error {
 	if bom == nil {
 		return fmt.Errorf("unable to write sbom to stream, SBOM is nil")
@@ -91,7 +98,7 @@ func (w *Writer) WriteStreamWithOptions(bom *sbom.Document, wr io.WriteCloser, o
 
 	serializer, err := GetFormatSerializer(format)
 	if err != nil {
-		return fmt.Errorf("getting serializer for format %s: %w", format, err)
+		return fmt.Errorf("getting serializer: %w", err)
 	}
 
 	key := fmt.Sprintf("%T", serializer)

--- a/pkg/writer/writer.go
+++ b/pkg/writer/writer.go
@@ -14,9 +14,9 @@ import (
 )
 
 type Writer struct {
-	RenderOptions   map[string]*native.RenderOptions
-	SerialzeOptions map[string]*native.SerializeOptions
-	Format          formats.Format
+	RenderOptions    map[string]*native.RenderOptions
+	SerializeOptions map[string]*native.SerializeOptions
+	Format           formats.Format
 }
 
 var (
@@ -32,8 +32,8 @@ var (
 
 func New(opts ...WriterOption) *Writer {
 	r := &Writer{
-		RenderOptions:   make(map[string]*native.RenderOptions),
-		SerialzeOptions: make(map[string]*native.SerializeOptions),
+		RenderOptions:    make(map[string]*native.RenderOptions),
+		SerializeOptions: make(map[string]*native.SerializeOptions),
 	}
 
 	for _, opt := range opts {
@@ -105,7 +105,7 @@ func (w *Writer) WriteStreamWithOptions(bom *sbom.Document, wr io.WriteCloser, o
 
 	so := o.SerializeOptions
 	if so == nil {
-		so = w.SerialzeOptions[key]
+		so = w.SerializeOptions[key]
 	}
 	nativeDoc, err := serializer.Serialize(bom, so)
 	if err != nil {
@@ -160,7 +160,7 @@ func (w *Writer) getOptions() (*Options, error) {
 		ro = defaultRenderOptions
 	}
 
-	so := w.SerialzeOptions[fmt.Sprintf("%T", s)]
+	so := w.SerializeOptions[fmt.Sprintf("%T", s)]
 	if so == nil {
 		so = defaultSerializeOptions
 	}


### PR DESCRIPTION
This PR completes some of the smaller nits outstanding from #102:

* Fixes a possible panic when casting the document to the native format in the CDX serializer
* Removes the default format when initializing the writer

It also fixes a bug where the serializer test would panic when testing for errors, it assumed a fixed number of executions in the fake tests.

Ahead of the cycle meeting we will cut a new release after this PR merges.

Signed-off-by: Adolfo Garcia Veytia (puerco) <puerco@chainguard.dev>