### PR TITLE
Fix panic on writer.WriteStreamWithOptions

### DIFF
--- a/pkg/native/serializers/serializer_spdx23.go
+++ b/pkg/native/serializers/serializer_spdx23.go
@@ -30,6 +30,9 @@ func NewSPDX23() *SPDX23 {
 
 func (s *SPDX23) Render(doc interface{}, wr io.Writer, o *native.RenderOptions) error {
 	// TODO: add support for XML
+	if o == nil {
+		o = &native.RenderOptions{}
+	}
 	encoder := json.NewEncoder(wr)
 	encoder.SetIndent("", strings.Repeat(" ", o.Indent))
 	if err := encoder.Encode(doc.(*spdx.Document)); err != nil {

--- a/pkg/writer/writer.go
+++ b/pkg/writer/writer.go
@@ -114,7 +114,11 @@ func (w *Writer) WriteStreamWithOptions(bom *sbom.Document, wr io.WriteCloser, o
 
 	ro := o.RenderOptions
 	if ro == nil {
-		ro = w.RenderOptions[key]
+		if _, ok := w.RenderOptions[key]; ok {
+			ro = w.RenderOptions[key]
+		} else {
+			ro = defaultRenderOptions
+		}
 	}
 	if err := serializer.Render(nativeDoc, wr, ro); err != nil {
 		return fmt.Errorf("writing rendered document to string: %w", err)


### PR DESCRIPTION
This PR fixes a panic when calling WriteStreamWithOptions

/cc @veramine @jspeed-meyers 

Signed-off-by: Adolfo Garcia Veytia (puerco) <puerco@chainguard.dev>