### PR TITLE
Reorganize options data structures

### DIFF
--- a/pkg/native/nativefakes/fake_serializer.go
+++ b/pkg/native/nativefakes/fake_serializer.go
@@ -10,12 +10,13 @@ import (
 )
 
 type FakeSerializer struct {
-	RenderStub        func(interface{}, io.Writer, *native.RenderOptions) error
+	RenderStub        func(interface{}, io.Writer, *native.RenderOptions, interface{}) error
 	renderMutex       sync.RWMutex
 	renderArgsForCall []struct {
 		arg1 interface{}
 		arg2 io.Writer
 		arg3 *native.RenderOptions
+		arg4 interface{}
 	}
 	renderReturns struct {
 		result1 error
@@ -23,11 +24,12 @@ type FakeSerializer struct {
 	renderReturnsOnCall map[int]struct {
 		result1 error
 	}
-	SerializeStub        func(*sbom.Document, *native.SerializeOptions) (interface{}, error)
+	SerializeStub        func(*sbom.Document, *native.SerializeOptions, interface{}) (interface{}, error)
 	serializeMutex       sync.RWMutex
 	serializeArgsForCall []struct {
 		arg1 *sbom.Document
 		arg2 *native.SerializeOptions
+		arg3 interface{}
 	}
 	serializeReturns struct {
 		result1 interface{}
@@ -41,20 +43,21 @@ type FakeSerializer struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeSerializer) Render(arg1 interface{}, arg2 io.Writer, arg3 *native.RenderOptions) error {
+func (fake *FakeSerializer) Render(arg1 interface{}, arg2 io.Writer, arg3 *native.RenderOptions, arg4 interface{}) error {
 	fake.renderMutex.Lock()
 	ret, specificReturn := fake.renderReturnsOnCall[len(fake.renderArgsForCall)]
 	fake.renderArgsForCall = append(fake.renderArgsForCall, struct {
 		arg1 interface{}
 		arg2 io.Writer
 		arg3 *native.RenderOptions
-	}{arg1, arg2, arg3})
+		arg4 interface{}
+	}{arg1, arg2, arg3, arg4})
 	stub := fake.RenderStub
 	fakeReturns := fake.renderReturns
-	fake.recordInvocation("Render", []interface{}{arg1, arg2, arg3})
+	fake.recordInvocation("Render", []interface{}{arg1, arg2, arg3, arg4})
 	fake.renderMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2, arg3)
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1
@@ -68,17 +71,17 @@ func (fake *FakeSerializer) RenderCallCount() int {
 	return len(fake.renderArgsForCall)
 }
 
-func (fake *FakeSerializer) RenderCalls(stub func(interface{}, io.Writer, *native.RenderOptions) error) {
+func (fake *FakeSerializer) RenderCalls(stub func(interface{}, io.Writer, *native.RenderOptions, interface{}) error) {
 	fake.renderMutex.Lock()
 	defer fake.renderMutex.Unlock()
 	fake.RenderStub = stub
 }
 
-func (fake *FakeSerializer) RenderArgsForCall(i int) (interface{}, io.Writer, *native.RenderOptions) {
+func (fake *FakeSerializer) RenderArgsForCall(i int) (interface{}, io.Writer, *native.RenderOptions, interface{}) {
 	fake.renderMutex.RLock()
 	defer fake.renderMutex.RUnlock()
 	argsForCall := fake.renderArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
 }
 
 func (fake *FakeSerializer) RenderReturns(result1 error) {
@@ -104,19 +107,20 @@ func (fake *FakeSerializer) RenderReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *FakeSerializer) Serialize(arg1 *sbom.Document, arg2 *native.SerializeOptions) (interface{}, error) {
+func (fake *FakeSerializer) Serialize(arg1 *sbom.Document, arg2 *native.SerializeOptions, arg3 interface{}) (interface{}, error) {
 	fake.serializeMutex.Lock()
 	ret, specificReturn := fake.serializeReturnsOnCall[len(fake.serializeArgsForCall)]
 	fake.serializeArgsForCall = append(fake.serializeArgsForCall, struct {
 		arg1 *sbom.Document
 		arg2 *native.SerializeOptions
-	}{arg1, arg2})
+		arg3 interface{}
+	}{arg1, arg2, arg3})
 	stub := fake.SerializeStub
 	fakeReturns := fake.serializeReturns
-	fake.recordInvocation("Serialize", []interface{}{arg1, arg2})
+	fake.recordInvocation("Serialize", []interface{}{arg1, arg2, arg3})
 	fake.serializeMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2)
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -130,17 +134,17 @@ func (fake *FakeSerializer) SerializeCallCount() int {
 	return len(fake.serializeArgsForCall)
 }
 
-func (fake *FakeSerializer) SerializeCalls(stub func(*sbom.Document, *native.SerializeOptions) (interface{}, error)) {
+func (fake *FakeSerializer) SerializeCalls(stub func(*sbom.Document, *native.SerializeOptions, interface{}) (interface{}, error)) {
 	fake.serializeMutex.Lock()
 	defer fake.serializeMutex.Unlock()
 	fake.SerializeStub = stub
 }
 
-func (fake *FakeSerializer) SerializeArgsForCall(i int) (*sbom.Document, *native.SerializeOptions) {
+func (fake *FakeSerializer) SerializeArgsForCall(i int) (*sbom.Document, *native.SerializeOptions, interface{}) {
 	fake.serializeMutex.RLock()
 	defer fake.serializeMutex.RUnlock()
 	argsForCall := fake.serializeArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
 func (fake *FakeSerializer) SerializeReturns(result1 interface{}, result2 error) {

--- a/pkg/native/serializer.go
+++ b/pkg/native/serializer.go
@@ -10,8 +10,8 @@ import (
 
 //counterfeiter:generate . Serializer
 type Serializer interface {
-	Serialize(*sbom.Document, *SerializeOptions) (interface{}, error)
-	Render(interface{}, io.Writer, *RenderOptions) error
+	Serialize(*sbom.Document, *SerializeOptions, interface{}) (interface{}, error)
+	Render(interface{}, io.Writer, *RenderOptions, interface{}) error
 }
 
 type RenderOptions struct {

--- a/pkg/native/serializer.go
+++ b/pkg/native/serializer.go
@@ -18,5 +18,4 @@ type RenderOptions struct {
 	Indent int
 }
 
-type SerializeOptions struct {
-}
+type SerializeOptions struct{}

--- a/pkg/native/serializer.go
+++ b/pkg/native/serializer.go
@@ -14,18 +14,9 @@ type Serializer interface {
 	Render(interface{}, io.Writer, *RenderOptions) error
 }
 
-type CommonRenderOptions struct {
+type RenderOptions struct {
 	Indent int
 }
 
-type CommonSerializeOptions struct{}
-
-type RenderOptions struct {
-	CommonRenderOptions
-	Options interface{}
-}
-
 type SerializeOptions struct {
-	CommonSerializeOptions
-	Options interface{}
 }

--- a/pkg/native/serializers/beta/serializer_spdx3.go
+++ b/pkg/native/serializers/beta/serializer_spdx3.go
@@ -114,7 +114,7 @@ type hashList struct {
 
 type SPDX3 struct{}
 
-func (spdx3 *SPDX3) Serialize(bom *sbom.Document, _ *native.SerializeOptions) (interface{}, error) {
+func (spdx3 *SPDX3) Serialize(bom *sbom.Document, _ *native.SerializeOptions, _ interface{}) (interface{}, error) {
 	now := time.Now()
 	spdxSBOM := sbomType{
 		Type: "Sbom",
@@ -240,7 +240,7 @@ func (spdx3 *SPDX3) nodeToFile(n *sbom.Node) (file, error) {
 	return f, nil
 }
 
-func (spdx3 *SPDX3) Render(rawDoc interface{}, w io.Writer, o *native.RenderOptions) error {
+func (spdx3 *SPDX3) Render(rawDoc interface{}, w io.Writer, o *native.RenderOptions, _ interface{}) error {
 	doc, ok := rawDoc.(sbomType)
 	if !ok {
 		return errors.New("unable to cast SBOM as an SPDX 3.0 SBOM")

--- a/pkg/native/serializers/serializer_cdx.go
+++ b/pkg/native/serializers/serializer_cdx.go
@@ -36,7 +36,7 @@ func NewCDX(version, encoding string) *CDX {
 	}
 }
 
-func (s *CDX) Serialize(bom *sbom.Document, _ *native.SerializeOptions) (interface{}, error) {
+func (s *CDX) Serialize(bom *sbom.Document, _ *native.SerializeOptions, _ interface{}) (interface{}, error) {
 	// Load the context with the CDX value. We initialize a context here
 	// but we should get it as part of the method to capture cancelations
 	// from the CLI or REST API.
@@ -426,7 +426,7 @@ func (s *CDX) nodeToComponent(n *sbom.Node) *cdx.Component {
 }
 
 // Render calls the official CDX serializer to render the BOM into a specific version
-func (s *CDX) Render(doc interface{}, wr io.Writer, o *native.RenderOptions) error {
+func (s *CDX) Render(doc interface{}, wr io.Writer, o *native.RenderOptions, _ interface{}) error {
 	if doc == nil {
 		return errors.New("document is nil")
 	}

--- a/pkg/native/serializers/serializer_spdx23.go
+++ b/pkg/native/serializers/serializer_spdx23.go
@@ -2,6 +2,7 @@ package serializers
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -41,6 +42,12 @@ func (s *SPDX23) Render(doc interface{}, wr io.Writer, o *native.RenderOptions) 
 
 // Serialize takes a protobom and returns an SPDX 2.3 struct
 func (s *SPDX23) Serialize(bom *sbom.Document, _ *native.SerializeOptions) (interface{}, error) {
+	if bom == nil {
+		return nil, errors.New("document is nil, unable to serialize to SPDX 2.3")
+	}
+	if bom.Metadata == nil {
+		return nil, errors.New("document metadata is nil, unable to serialize to SPDX 2.3")
+	}
 	doc := &spdx.Document{
 		SPDXVersion:       spdx.Version,
 		DataLicense:       spdx.DataLicense,

--- a/pkg/native/serializers/serializer_spdx23.go
+++ b/pkg/native/serializers/serializer_spdx23.go
@@ -29,7 +29,7 @@ func NewSPDX23() *SPDX23 {
 	return &SPDX23{}
 }
 
-func (s *SPDX23) Render(doc interface{}, wr io.Writer, o *native.RenderOptions) error {
+func (s *SPDX23) Render(doc interface{}, wr io.Writer, o *native.RenderOptions, _ interface{}) error {
 	// TODO: add support for XML
 	encoder := json.NewEncoder(wr)
 	encoder.SetIndent("", strings.Repeat(" ", o.Indent))
@@ -41,7 +41,7 @@ func (s *SPDX23) Render(doc interface{}, wr io.Writer, o *native.RenderOptions) 
 }
 
 // Serialize takes a protobom and returns an SPDX 2.3 struct
-func (s *SPDX23) Serialize(bom *sbom.Document, _ *native.SerializeOptions) (interface{}, error) {
+func (s *SPDX23) Serialize(bom *sbom.Document, _ *native.SerializeOptions, _ interface{}) (interface{}, error) {
 	if bom == nil {
 		return nil, errors.New("document is nil, unable to serialize to SPDX 2.3")
 	}

--- a/pkg/writer/options.go
+++ b/pkg/writer/options.go
@@ -64,7 +64,7 @@ func (o *Options) GetFormatOptions(key interface{}) interface{} {
 	return nil
 }
 
-func (o *Options) SetFormatOptions(key interface{}, opts interface{}) {
+func (o *Options) SetFormatOptions(key, opts interface{}) {
 	if o.formatOptions == nil {
 		o.formatOptions = map[string]interface{}{}
 	}

--- a/pkg/writer/options.go
+++ b/pkg/writer/options.go
@@ -1,33 +1,39 @@
 package writer
 
 import (
+	"fmt"
+
 	"github.com/bom-squad/protobom/pkg/formats"
 	"github.com/bom-squad/protobom/pkg/native"
 )
 
 type WriterOption func(*Writer)
 
-func WithRenderOptions(ro map[string]*native.RenderOptions) WriterOption {
+func WithRenderOptions(ro *native.RenderOptions) WriterOption {
 	return func(w *Writer) {
 		if ro != nil {
-			w.RenderOptions = ro
+			w.Options.RenderOptions = ro
 		}
 	}
 }
 
-func WithSerializeOptions(so map[string]*native.SerializeOptions) WriterOption {
+func WithSerializeOptions(so *native.SerializeOptions) WriterOption {
 	return func(w *Writer) {
 		if so != nil {
-			w.SerializeOptions = so
+			w.Options.SerializeOptions = so
 		}
+	}
+}
+
+func WithFormatOptions(driverKey string, opts interface{}) WriterOption {
+	return func(w *Writer) {
+		w.Options.SetFormatOptions(driverKey, opts)
 	}
 }
 
 func WithFormat(f formats.Format) WriterOption {
 	return func(w *Writer) {
-		if f != "" {
-			w.Format = f
-		}
+		w.Options.Format = f
 	}
 }
 
@@ -35,4 +41,36 @@ type Options struct {
 	Format           formats.Format
 	RenderOptions    *native.RenderOptions
 	SerializeOptions *native.SerializeOptions
+	formatOptions    map[string]interface{}
+}
+
+// argToOptsKeyVal returns a key value to access the options dictionary by using
+// key as a string or its type if its a serializer driver.
+func argToOptsKeyVal(key interface{}) string {
+	keyVal, ok := key.(string)
+	if !ok {
+		keyVal = fmt.Sprintf("%T", key)
+	}
+
+	return keyVal
+}
+
+func (o *Options) GetFormatOptions(key interface{}) interface{} {
+	keyVal := argToOptsKeyVal(key)
+	if _, ok := o.formatOptions[keyVal]; ok {
+		return o.formatOptions[keyVal]
+	}
+	// TODO(puerco): create new options struct for serializer
+	return nil
+}
+
+func (o *Options) SetFormatOptions(key interface{}, opts interface{}) {
+	if o.formatOptions == nil {
+		o.formatOptions = map[string]interface{}{}
+	}
+	keyVal := argToOptsKeyVal(key)
+	if keyVal == "" {
+		return
+	}
+	o.formatOptions[keyVal] = opts
 }

--- a/pkg/writer/writer.go
+++ b/pkg/writer/writer.go
@@ -104,7 +104,7 @@ func (w *Writer) WriteStreamWithOptions(bom *sbom.Document, wr io.WriteCloser, o
 		so = defaultOptions.SerializeOptions
 	}
 
-	nativeDoc, err := serializer.Serialize(bom, so)
+	nativeDoc, err := serializer.Serialize(bom, so, o.GetFormatOptions(serializer))
 	if err != nil {
 		return fmt.Errorf("serializing SBOM to native format: %w", err)
 	}
@@ -114,7 +114,7 @@ func (w *Writer) WriteStreamWithOptions(bom *sbom.Document, wr io.WriteCloser, o
 		ro = defaultOptions.RenderOptions
 	}
 
-	if err := serializer.Render(nativeDoc, wr, ro); err != nil {
+	if err := serializer.Render(nativeDoc, wr, ro, o.GetFormatOptions(serializer)); err != nil {
 		return fmt.Errorf("writing rendered document to string: %w", err)
 	}
 

--- a/pkg/writer/writer.go
+++ b/pkg/writer/writer.go
@@ -14,33 +14,31 @@ import (
 )
 
 type Writer struct {
-	RenderOptions    map[string]*native.RenderOptions
-	SerializeOptions map[string]*native.SerializeOptions
-	Format           formats.Format
+	Options *Options
 }
 
 var (
-	regMtx               sync.RWMutex
-	serializers          = make(map[formats.Format]native.Serializer)
-	defaultRenderOptions = &native.RenderOptions{
-		CommonRenderOptions: native.CommonRenderOptions{
+	regMtx         sync.RWMutex
+	serializers    = make(map[formats.Format]native.Serializer)
+	defaultOptions = &Options{
+		RenderOptions: &native.RenderOptions{
 			Indent: 4,
 		},
+		SerializeOptions: &native.SerializeOptions{},
+		formatOptions:    map[string]interface{}{},
 	}
-	defaultSerializeOptions = &native.SerializeOptions{}
 )
 
 func New(opts ...WriterOption) *Writer {
-	r := &Writer{
-		RenderOptions:    make(map[string]*native.RenderOptions),
-		SerializeOptions: make(map[string]*native.SerializeOptions),
+	w := &Writer{
+		Options: defaultOptions,
 	}
 
 	for _, opt := range opts {
-		opt(r)
+		opt(w)
 	}
 
-	return r
+	return w
 }
 
 func init() {
@@ -93,7 +91,7 @@ func (w *Writer) WriteStreamWithOptions(bom *sbom.Document, wr io.WriteCloser, o
 
 	format := o.Format
 	if o.Format == "" {
-		format = w.Format
+		format = w.Options.Format
 	}
 
 	serializer, err := GetFormatSerializer(format)
@@ -101,12 +99,11 @@ func (w *Writer) WriteStreamWithOptions(bom *sbom.Document, wr io.WriteCloser, o
 		return fmt.Errorf("getting serializer: %w", err)
 	}
 
-	key := fmt.Sprintf("%T", serializer)
-
 	so := o.SerializeOptions
 	if so == nil {
-		so = w.SerializeOptions[key]
+		so = defaultOptions.SerializeOptions
 	}
+
 	nativeDoc, err := serializer.Serialize(bom, so)
 	if err != nil {
 		return fmt.Errorf("serializing SBOM to native format: %w", err)
@@ -114,8 +111,9 @@ func (w *Writer) WriteStreamWithOptions(bom *sbom.Document, wr io.WriteCloser, o
 
 	ro := o.RenderOptions
 	if ro == nil {
-		ro = w.RenderOptions[key]
+		ro = defaultOptions.RenderOptions
 	}
+
 	if err := serializer.Render(nativeDoc, wr, ro); err != nil {
 		return fmt.Errorf("writing rendered document to string: %w", err)
 	}
@@ -124,11 +122,7 @@ func (w *Writer) WriteStreamWithOptions(bom *sbom.Document, wr io.WriteCloser, o
 }
 
 func (w *Writer) WriteStream(bom *sbom.Document, wr io.WriteCloser) error {
-	options, err := w.getOptions()
-	if err != nil {
-		return err
-	}
-	return w.WriteStreamWithOptions(bom, wr, options)
+	return w.WriteStreamWithOptions(bom, wr, w.Options)
 }
 
 // WriteFile takes an sbom.Document and writes it to the file at path
@@ -141,33 +135,8 @@ func (w *Writer) WriteFileWithOptions(bom *sbom.Document, path string, o *Option
 	return w.WriteStreamWithOptions(bom, f, o)
 }
 
+// WriteFile
 func (w *Writer) WriteFile(bom *sbom.Document, path string) error {
-	options, err := w.getOptions()
-	if err != nil {
-		return err
-	}
-	return w.WriteFileWithOptions(bom, path, options)
-}
-
-func (w *Writer) getOptions() (*Options, error) {
-	s, err := GetFormatSerializer(w.Format)
-	if err != nil {
-		return nil, err
-	}
-
-	ro := w.RenderOptions[fmt.Sprintf("%T", s)]
-	if ro == nil {
-		ro = defaultRenderOptions
-	}
-
-	so := w.SerializeOptions[fmt.Sprintf("%T", s)]
-	if so == nil {
-		so = defaultSerializeOptions
-	}
-
-	return &Options{
-		Format:           w.Format,
-		RenderOptions:    ro,
-		SerializeOptions: so,
-	}, nil
+	return w.WriteFileWithOptions(
+		bom, path, w.Options)
 }

--- a/pkg/writer/writer_test.go
+++ b/pkg/writer/writer_test.go
@@ -230,10 +230,10 @@ func TestWriteStream(t *testing.T) {
 			} else {
 				r.NoError(err)
 				if tt.ro != nil {
-					_, _, a := fakeSerializer.RenderArgsForCall(fakeSerializer.RenderCallCount() - 1)
+					_, _, a, _ := fakeSerializer.RenderArgsForCall(fakeSerializer.RenderCallCount() - 1)
 					r.Equal(tt.ro, a)
 
-					_, b := fakeSerializer.SerializeArgsForCall(fakeSerializer.SerializeCallCount() - 1)
+					_, b, _ := fakeSerializer.SerializeArgsForCall(fakeSerializer.SerializeCallCount() - 1)
 					r.Equal(tt.so, b)
 				}
 			}
@@ -320,10 +320,10 @@ func TestWriteFile(t *testing.T) {
 			} else {
 				r.NoError(err)
 				if tt.ro != nil {
-					_, _, a := fakeSerializer.RenderArgsForCall(fakeSerializer.RenderCallCount() - 1)
+					_, _, a, _ := fakeSerializer.RenderArgsForCall(fakeSerializer.RenderCallCount() - 1)
 					r.Equal(tt.ro, a)
 
-					_, b := fakeSerializer.SerializeArgsForCall(fakeSerializer.SerializeCallCount() - 1)
+					_, b, _ := fakeSerializer.SerializeArgsForCall(fakeSerializer.SerializeCallCount() - 1)
 					r.Equal(tt.so, b)
 				}
 			}


### PR DESCRIPTION
This PR restructures the options data structures to address the problems delineated in #122. It is a set of changes to improve the usability and consistency of the writer object and its option. The changes are as follows:

* It modifies the writer to have a single options struct that embeds a single instance of the render and serialize options while keeping a catalog to host each of the serializer driver functions.
* The serializer functions now take a set of common options (render and serialize options) and the native serializer options.
* The fakes have been updated accordingly.
* The writer options now have functions to set and get each driver's options set.
* Tests are updated to handle the new universal options struct

The new options struct looks as follows:

```golang
type Options struct {
	// Writer Options:
	Format           formats.Format
	// FutureOption1
	// FutureOption2

	// Embedded Render options
	RenderOptions    *native.RenderOptions 

	// Embedded  Serialize Options
	SerializeOptions *native.SerializeOptions

	// Serializer Dirver native options catalog
	formatOptions    map[string]interface{
                 string(formats.SPDX23JSON): spdxOpts{},
                 string(formats.CDX14JSON): spdxOpts{},
        }
}
```

Fixes #122

Signed-off-by: Adolfo Garcia Veytia (puerco) <puerco@chainguard.dev>