### PR TITLE
Restructure reader options

### DIFF
--- a/pkg/native/nativefakes/fake_unserializer.go
+++ b/pkg/native/nativefakes/fake_unserializer.go
@@ -10,11 +10,12 @@ import (
 )
 
 type FakeUnserializer struct {
-	UnserializeStub        func(io.Reader, *native.UnserializeOptions) (*sbom.Document, error)
+	UnserializeStub        func(io.Reader, *native.UnserializeOptions, interface{}) (*sbom.Document, error)
 	unserializeMutex       sync.RWMutex
 	unserializeArgsForCall []struct {
 		arg1 io.Reader
 		arg2 *native.UnserializeOptions
+		arg3 interface{}
 	}
 	unserializeReturns struct {
 		result1 *sbom.Document
@@ -28,19 +29,20 @@ type FakeUnserializer struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeUnserializer) Unserialize(arg1 io.Reader, arg2 *native.UnserializeOptions) (*sbom.Document, error) {
+func (fake *FakeUnserializer) Unserialize(arg1 io.Reader, arg2 *native.UnserializeOptions, arg3 interface{}) (*sbom.Document, error) {
 	fake.unserializeMutex.Lock()
 	ret, specificReturn := fake.unserializeReturnsOnCall[len(fake.unserializeArgsForCall)]
 	fake.unserializeArgsForCall = append(fake.unserializeArgsForCall, struct {
 		arg1 io.Reader
 		arg2 *native.UnserializeOptions
-	}{arg1, arg2})
+		arg3 interface{}
+	}{arg1, arg2, arg3})
 	stub := fake.UnserializeStub
 	fakeReturns := fake.unserializeReturns
-	fake.recordInvocation("Unserialize", []interface{}{arg1, arg2})
+	fake.recordInvocation("Unserialize", []interface{}{arg1, arg2, arg3})
 	fake.unserializeMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2)
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -54,17 +56,17 @@ func (fake *FakeUnserializer) UnserializeCallCount() int {
 	return len(fake.unserializeArgsForCall)
 }
 
-func (fake *FakeUnserializer) UnserializeCalls(stub func(io.Reader, *native.UnserializeOptions) (*sbom.Document, error)) {
+func (fake *FakeUnserializer) UnserializeCalls(stub func(io.Reader, *native.UnserializeOptions, interface{}) (*sbom.Document, error)) {
 	fake.unserializeMutex.Lock()
 	defer fake.unserializeMutex.Unlock()
 	fake.UnserializeStub = stub
 }
 
-func (fake *FakeUnserializer) UnserializeArgsForCall(i int) (io.Reader, *native.UnserializeOptions) {
+func (fake *FakeUnserializer) UnserializeArgsForCall(i int) (io.Reader, *native.UnserializeOptions, interface{}) {
 	fake.unserializeMutex.RLock()
 	defer fake.unserializeMutex.RUnlock()
 	argsForCall := fake.unserializeArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
 func (fake *FakeUnserializer) UnserializeReturns(result1 *sbom.Document, result2 error) {

--- a/pkg/native/unserializer.go
+++ b/pkg/native/unserializer.go
@@ -10,12 +10,7 @@ import (
 
 //counterfeiter:generate . Unserializer
 type Unserializer interface {
-	Unserialize(io.Reader, *UnserializeOptions) (*sbom.Document, error)
+	Unserialize(io.Reader, *UnserializeOptions, interface{}) (*sbom.Document, error)
 }
 
-type CommonUnserializeOptions struct{}
-
-type UnserializeOptions struct {
-	CommonUnserializeOptions
-	Options interface{}
-}
+type UnserializeOptions struct{}

--- a/pkg/native/unserializers/unserializer_cdx.go
+++ b/pkg/native/unserializers/unserializer_cdx.go
@@ -30,7 +30,7 @@ func NewCDX(version, encoding string) *CDX {
 
 // Unserialize reads datq data from io.Reader r and parses it as a CycloneDX
 // document. If successful returns a protobom Document loaded with the SBOM data.
-func (u *CDX) Unserialize(r io.Reader, _ *native.UnserializeOptions) (*sbom.Document, error) {
+func (u *CDX) Unserialize(r io.Reader, _ *native.UnserializeOptions, _ interface{}) (*sbom.Document, error) {
 	bom := new(cdx.BOM)
 
 	encoding, err := cdxformats.ParseEncoding(u.encoding)

--- a/pkg/native/unserializers/unserializer_spdx23.go
+++ b/pkg/native/unserializers/unserializer_spdx23.go
@@ -25,7 +25,7 @@ func NewSPDX23() *SPDX23 {
 }
 
 // ParseStream reads an io.Reader to parse an SPDX 2.3 document from it
-func (u *SPDX23) Unserialize(r io.Reader, _ *native.UnserializeOptions) (*sbom.Document, error) {
+func (u *SPDX23) Unserialize(r io.Reader, _ *native.UnserializeOptions, _ interface{}) (*sbom.Document, error) {
 	spdxDoc, err := spdxjson.Read(r)
 	if err != nil {
 		return nil, fmt.Errorf("parsing SPDX json: %w", err)

--- a/pkg/reader/options.go
+++ b/pkg/reader/options.go
@@ -1,29 +1,68 @@
 package reader
 
 import (
+	"fmt"
+
 	"github.com/bom-squad/protobom/pkg/formats"
 	"github.com/bom-squad/protobom/pkg/native"
 )
 
+type Options struct {
+	Format             formats.Format
+	UnserializeOptions *native.UnserializeOptions
+	formatOptions      map[string]interface{}
+}
+
+// argToOptsKeyVal returns a key value to access the options dictionary by using
+// key as a string or its type if its a serializer driver.
+func argToOptsKeyVal(key interface{}) string {
+	keyVal, ok := key.(string)
+	if !ok {
+		keyVal = fmt.Sprintf("%T", key)
+	}
+
+	return keyVal
+}
+
+func (o *Options) GetFormatOptions(key interface{}) interface{} {
+	keyVal := argToOptsKeyVal(key)
+	if _, ok := o.formatOptions[keyVal]; ok {
+		return o.formatOptions[keyVal]
+	}
+	return nil
+}
+
+func (o *Options) SetFormatOptions(key, opts interface{}) {
+	if o.formatOptions == nil {
+		o.formatOptions = map[string]interface{}{}
+	}
+	keyVal := argToOptsKeyVal(key)
+	if keyVal == "" {
+		return
+	}
+	o.formatOptions[keyVal] = opts
+}
+
 type ReaderOption func(*Reader)
 
-func WithUnserializeOptions(uo map[string]*native.UnserializeOptions) ReaderOption {
-	return func(w *Reader) {
+func WithFormatOptions(driverKey string, opts interface{}) ReaderOption {
+	return func(r *Reader) {
+		r.Options.SetFormatOptions(driverKey, opts)
+	}
+}
+
+func WithUnserializeOptions(uo *native.UnserializeOptions) ReaderOption {
+	return func(r *Reader) {
 		if uo != nil {
-			w.UnserializeOptions = uo
+			r.Options.UnserializeOptions = uo
 		}
 	}
 }
 
 func WithSniffer(s Sniffer) ReaderOption {
-	return func(w *Reader) {
+	return func(r *Reader) {
 		if s != nil {
-			w.sniffer = s
+			r.sniffer = s
 		}
 	}
-}
-
-type Options struct {
-	Format             formats.Format
-	UnserializeOptions *native.UnserializeOptions
 }

--- a/pkg/reader/reader_test.go
+++ b/pkg/reader/reader_test.go
@@ -31,7 +31,6 @@ func (f *fakeReadSeeker) Read(p []byte) (int, error) {
 
 func TestReader_ParseFile(t *testing.T) {
 	fake := &nativefakes.FakeUnserializer{}
-	fakeKey := fmt.Sprintf("%T", fake)
 	fakeSniffer := &readerfakes.FakeSniffer{}
 	doc := &sbom.Document{}
 	tests := []struct {
@@ -121,9 +120,7 @@ func TestReader_ParseFile(t *testing.T) {
 
 			rdr := reader.New(
 				reader.WithSniffer(fakeSniffer),
-				reader.WithUnserializeOptions(map[string]*native.UnserializeOptions{
-					fakeKey: tt.uo,
-				}),
+				reader.WithUnserializeOptions(&native.UnserializeOptions{}),
 			)
 
 			doc, err := rdr.ParseFile(tt.path)
@@ -133,7 +130,7 @@ func TestReader_ParseFile(t *testing.T) {
 				r.NoError(err)
 				r.Equal(tt.want, doc)
 				if tt.uo != nil {
-					_, a := fake.UnserializeArgsForCall(i)
+					_, a, _ := fake.UnserializeArgsForCall(i)
 					r.Equal(tt.uo, a)
 				}
 			}
@@ -339,9 +336,10 @@ func TestReader_ParseStream(t *testing.T) {
 			rdr := reader.New(
 				reader.WithSniffer(fakeSniffer),
 				reader.WithUnserializeOptions(
-					map[string]*native.UnserializeOptions{
-						fakeKey: tt.uo,
-					},
+					&native.UnserializeOptions{},
+				),
+				reader.WithFormatOptions(
+					fakeKey, struct{}{},
 				),
 			)
 			doc, err := rdr.ParseStream(&fakeReadSeeker{})
@@ -351,7 +349,7 @@ func TestReader_ParseStream(t *testing.T) {
 				r.NoError(err)
 				r.Equal(tt.want, doc)
 				if tt.uo != nil {
-					_, a := fake.UnserializeArgsForCall(i)
+					_, a, _ := fake.UnserializeArgsForCall(i)
 					r.Equal(tt.uo, a)
 				}
 			}


### PR DESCRIPTION
This PR restructures the reader options just as we did for the writer options in #123. It basically creates a single Options set that embeds the unserializer and a collection for the serializer driver options. It is a big PR but it is mostly harmless as we don't have any options defined yet and the design principles are the same as in #123:

```golang
type Options struct {
	Format             formats.Format
	UnserializeOptions: *native.UnserializeOptions {}
	formatOptions      map[string]interface{}
}
```

Note: This is a blocker for cutting v0.2.0 as it evens out the patterns in the readers and writers.

Signed-off-by: Adolfo Garcia Veytia (puerco) <puerco@chainguard.dev>