### PR TITLE
Allow serialization of SBOM with no rootComponent

### DIFF
--- a/pkg/native/serializers/serializer_cdx.go
+++ b/pkg/native/serializers/serializer_cdx.go
@@ -62,11 +62,10 @@ func (s *CDX) Serialize(bom *sbom.Document, _ *native.SerializeOptions, _ interf
 	rootComponent, err := s.root(ctx, bom)
 	if err != nil {
 		return nil, fmt.Errorf("generating SBOM root component: %w", err)
-	} else if rootComponent == nil {
-		return nil, fmt.Errorf("No SBOM root component")
+	} 
+	if rootComponent != nil {
+		doc.Metadata.Component = rootComponent
 	}
-
-	doc.Metadata.Component = rootComponent
 	if err := s.componentsMaps(ctx, bom); err != nil {
 		return nil, err
 	}

--- a/pkg/native/serializers/serializer_cdx.go
+++ b/pkg/native/serializers/serializer_cdx.go
@@ -62,7 +62,8 @@ func (s *CDX) Serialize(bom *sbom.Document, _ *native.SerializeOptions, _ interf
 	rootComponent, err := s.root(ctx, bom)
 	if err != nil {
 		return nil, fmt.Errorf("generating SBOM root component: %w", err)
-	} 
+	}
+
 	if rootComponent != nil {
 		doc.Metadata.Component = rootComponent
 	}


### PR DESCRIPTION
With CycloneDX, the root node is expected to be in the node list.  However, in SPDX the Document section can be the root node with no package or file otherwise acting as the root node.  I had previously added a check in the CycloneDX serializer to reject protobom documents where the root node was not in the node list.  (https://github.com/bom-squad/protobom/pull/109)  That change does not allow some protobom documents originating from a valid SPDX document to be written to CycloneDX.  See https://github.com/bom-squad/protobom/issues/126.

Example originating SBOM:  
[in.json](https://github.com/bom-squad/protobom/files/12899027/in.json)

With this change, we allow CDX serialization of protobom Documents where the root node is not in the Node List.  I contemplated instead adding a fake node to the node list but decided not to.  Happy to reconsider that and explicitly add a node to the node list when it is missing and then reference that as the root if the community thinks that is the right approach.  

This change unblocks https://github.com/bom-squad/sbom-convert/pull/13