### PR TITLE
ignore lint errors of type SA9003: empty branch

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -10,6 +10,9 @@ issues:
         - gocritic
         - golint
         - dupl
+    - linters:
+        - staticcheck
+      text: "^SA9003:"  # Ignore empty branch lint errors while we are scaffolding new functionality
 
   # Maximum issues count per one linter. Set to 0 to disable. Default is 50.
   max-issues-per-linter: 0


### PR DESCRIPTION
Proposal to allow lint errors of type empty branch until we get to protobom v1.0.  

I want to add checks for degradation like this:

```golang
if len(node.PrimaryPurpose) > 1 {
	// TODO(degradation): Multiple PrimaryPurpose in protobom.Node, but spdx.Package only allows single PrimaryPackagePurpose so we are using the first
}
```

But I can't because lint error of empty branch.  So instead I do things like this:

```golang
if len(node.PrimaryPurpose) > 1 {
	// TODO(degradation): Multiple PrimaryPurpose in protobom.Node, but spdx.Package only allows single PrimaryPackagePurpose so we are using the first
	if true { // temp workaround in favor of adding a lint tag
		break
	}
}
```

and this

```golang
func noop() {}
...
default:
	// TODO(degradation): Non-matching primary purpose to component type mapping
	noop() // temp workaround in favor of adding a lint tag
```

I'm proposing we relax the lint checks for empty branches so we can leave these empty branches we intend to fill in prior to v1.0.  Here's the change:

```yml
    - linters:
        - staticcheck
      text: "^SA9003:"  # Ignore empty branch lint errors while we are scaffolding new functionality
```

Here's the kind of errors we would stop getting on check-in:

```
pkg/native/serializers/serializer_cdx.go:308:3: SA9003: empty branch (staticcheck)
		if len(n.PrimaryPurpose) > 1 {
```