### PR TITLE
Graph API improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ func main() {
 	// Create a node to represent the application:
 	appNode := &sbom.Node{
 		Id:               "pkg:generic/my-software@v1.0.0",
-		PrimaryPurpose:   "application",
+		PrimaryPurpose:   []sbom.Purpose{sbom.Purpose_APPLICATION},
 		Name:             "My Software Name",
 		Version:          "v1.0.0",
 		Licenses:         []string{"Apache-2.0"},

--- a/README.md
+++ b/README.md
@@ -119,9 +119,7 @@ func main() {
 	}
 
 	// Add the application node to the document's nodelist:
-	document.NodeList.AddNode(appNode)
-	// ... and to the document's root elements:
-	document.NodeList.RootElements = append(document.NodeList.RootElements, appNode.Id)
+	document.NodeList.AddRootNode(appNode)
 
 	// Create two nodes to describe files in the application
 
@@ -134,11 +132,9 @@ func main() {
 		Description: "Software Lib",
 	}
 
-	node1.Hashes = map[int32]string{
-		int32(sbom.HashAlgorithm_SHA1):   "f3ae11065cafc14e27a1410ae8be28e600bb8336",
-		int32(sbom.HashAlgorithm_SHA256): "4f232eeb99e1663d07f0af1af6ea262bf594934b694228e71fd8f159f9a19f32",
-		int32(sbom.HashAlgorithm_SHA512): "8044d0df34242699ad73bfe99b9ac3d6bbdaa4f8ebce1e23ee5c7f9fe59db8ad7b01fe94e886941793aee802008a35b05a30bc51426db796aa21e5e91b7ed9be",
-	}
+	node1.AddHash(sbom.HashAlgorithm_SHA1, "f3ae11065cafc14e27a1410ae8be28e600bb8336")
+	node1.AddHash(sbom.HashAlgorithm_SHA256, "4f232eeb99e1663d07f0af1af6ea262bf594934b694228e71fd8f159f9a19f32")
+	node1.AddHash(sbom.HashAlgorithm_SHA512, "8044d0df34242699ad73bfe99b9ac3d6bbdaa4f8ebce1e23ee5c7f9fe59db8ad7b01fe94e886941793aee802008a35b05a30bc51426db796aa21e5e91b7ed9be")
 
 	document.NodeList.AddNode(node1)
 
@@ -146,27 +142,19 @@ func main() {
 		Id:          "File--usr-bin-software",
 		Type:        sbom.Node_FILE,
 		Name:        "/usr/bin/software",
-		Version:     "1",
+		Version:     "1.0",
 		Copyright:   "Copyright 2023 The ACME Corporation",
 		Description: "Software binary",
 	}
 
-	node2.Hashes = map[int32]string{
-		int32(sbom.HashAlgorithm_SHA1):   "defee82004d22fc92ab81c0c952a62a2172bda8c",
-		int32(sbom.HashAlgorithm_SHA256): "ad291c9572af8fc2ec8fd78d295adf7132c60ad3d10488fb63d120fc967a4132",
-		int32(sbom.HashAlgorithm_SHA512): "5940d8647907831e77ec00d81b318ca06655dbb0fd36d112684b03947412f0f98ea85b32548bc0877f3d7ce8f4de9b2c964062df44742b98c8e9bd851faecce9",
-	}
+	node2.AddHash(sbom.HashAlgorithm_SHA1, "defee82004d22fc92ab81c0c952a62a2172bda8c")
+	node2.AddHash(sbom.HashAlgorithm_SHA256, "ad291c9572af8fc2ec8fd78d295adf7132c60ad3d10488fb63d120fc967a4132")
+	node2.AddHash(sbom.HashAlgorithm_SHA512,  "5940d8647907831e77ec00d81b318ca06655dbb0fd36d112684b03947412f0f98ea85b32548bc0877f3d7ce8f4de9b2c964062df44742b98c8e9bd851faecce9")
 
-	document.NodeList.AddNode(node2)
-
-	// Relate the application package and the files:
-	edge := &sbom.Edge{
-		Type: sbom.Edge_contains,
-		From: appNode.Id,
-		To:   []string{node1.Id, node2.Id},
-	}
-
-	document.NodeList.Edges = append(document.NodeList.Edges, edge)
+	// Relate the application package and the files. This adds the nodes to 
+	// the document graph:
+	document.RelateNodeAtID(node1, appNode.Id, sbom.Edge_contains)
+	document.RelateNodeAtID(node2, appNode.Id, sbom.Edge_contains)
 
 	// Now render the document to STDOUT:
 	w := writer.New()

--- a/pkg/sbom/edge.go
+++ b/pkg/sbom/edge.go
@@ -5,6 +5,12 @@ import (
 	"strings"
 )
 
+func NewEdge() *Edge {
+	return &Edge{
+		To: []string{},
+	}
+}
+
 // Copy returns a new edge with copies of all edges
 func (e *Edge) Copy() *Edge {
 	return &Edge{

--- a/pkg/sbom/node.go
+++ b/pkg/sbom/node.go
@@ -16,6 +16,19 @@ import (
 // updates to the node proto should also be reflected in most of these
 // functions as they operate on the Node's fields
 
+func NewNode() *Node {
+	return &Node{
+		Licenses:           []string{},
+		Attribution:        []string{},
+		Suppliers:          []*Person{},
+		Originators:        []*Person{},
+		ExternalReferences: []*ExternalReference{},
+		FileTypes:          []string{},
+		Identifiers:        map[int32]string{},
+		Hashes:             map[int32]string{},
+	}
+}
+
 // Update updates a node's fields with information from the second node
 // Any fields in n2 which are not null (empty string, lists longer than 0 or not nill
 // pointers will overwrite fields in Node n.

--- a/pkg/sbom/node.go
+++ b/pkg/sbom/node.go
@@ -370,3 +370,15 @@ func (n *Node) HashesMatch(th map[int32]string) bool {
 	}
 	return atLeastOneMatch
 }
+
+// AddHash adds a new hash of algorithm algo to the node. If the node
+// already has a hash of the same algorithm it will get silently replaced.
+func (n *Node) AddHash(algo HashAlgorithm, value string) {
+	if value == "" {
+		return
+	}
+	if n.Hashes == nil {
+		n.Hashes = map[int32]string{}
+	}
+	n.Hashes[int32(algo)] = value
+}

--- a/pkg/sbom/node_test.go
+++ b/pkg/sbom/node_test.go
@@ -410,3 +410,50 @@ func TestNodeDescendants(t *testing.T) {
 		})
 	}
 }
+
+func TestNodeAddHash(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		sut      *Node
+		algo     HashAlgorithm
+		val      string
+		expected map[int32]string
+	}{
+		{
+			name: "regular add",
+			sut:  &Node{Hashes: map[int32]string{}},
+			algo: HashAlgorithm_SHA256,
+			val:  "a127ceedc934ccbe6e5fc2fac4c1afa2bf59271d2df288dd0cba01fbf93ce694",
+			expected: map[int32]string{
+				int32(HashAlgorithm_SHA256): "a127ceedc934ccbe6e5fc2fac4c1afa2bf59271d2df288dd0cba01fbf93ce694",
+			},
+		},
+		{
+			name: "replace existing",
+			sut: &Node{Hashes: map[int32]string{
+				int32(HashAlgorithm_SHA256): "a127ceedc934ccbe6e5fc2fac4c1afa2bf59271d2df288dd0cba01fbf93ce694",
+			}},
+			algo: HashAlgorithm_SHA256,
+			val:  "c2c306cf6281251126b8bff2e747d89019de78de51324f3a48f9c83b794be46c",
+			expected: map[int32]string{
+				int32(HashAlgorithm_SHA256): "c2c306cf6281251126b8bff2e747d89019de78de51324f3a48f9c83b794be46c",
+			},
+		},
+		{
+			name: "empty hash does not replace value",
+			sut: &Node{Hashes: map[int32]string{
+				int32(HashAlgorithm_SHA256): "a127ceedc934ccbe6e5fc2fac4c1afa2bf59271d2df288dd0cba01fbf93ce694",
+			}},
+			algo: HashAlgorithm_SHA256,
+			val:  "",
+			expected: map[int32]string{
+				int32(HashAlgorithm_SHA256): "a127ceedc934ccbe6e5fc2fac4c1afa2bf59271d2df288dd0cba01fbf93ce694",
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.sut.AddHash(tc.algo, tc.val)
+			require.True(t, tc.sut.Equal(&Node{Hashes: tc.expected}))
+		})
+	}
+}

--- a/pkg/sbom/node_test.go
+++ b/pkg/sbom/node_test.go
@@ -304,3 +304,109 @@ func TestNodeCopy(t *testing.T) {
 	require.Equal(t, "f3ae11065cafc14e27a1410ae8be28e600bb8336", copied.Hashes[int32(HashAlgorithm_SHA1)])
 	require.Equal(t, "TEXT", copied.FileTypes[0])
 }
+
+func TestNodeDescendants(t *testing.T) {
+	sutId := "mynode"
+	for _, tc := range []struct {
+		name                string
+		sut                 *NodeList
+		expectedNodesLength int
+		depth               int
+	}{
+		{
+			// SA graph with a single node. We should get a one node result but
+			// we use a max distance of 10 to catch any possible errors traversing
+			// the graph that could lead to duplications.
+			//
+			//     mynode
+			//       |
+			name: "single node",
+			sut: &NodeList{
+				Nodes:        []*Node{{Id: sutId}},
+				Edges:        []*Edge{},
+				RootElements: []string{sutId},
+			},
+			expectedNodesLength: 1,
+			depth:               10,
+		},
+		{
+			//     mynode
+			//     /    \
+			// child1  child2
+			name: "two descendants one level",
+			sut: &NodeList{
+				Nodes: []*Node{{Id: sutId}, {Id: "child1"}, {Id: "child2"}},
+				Edges: []*Edge{{
+					From: sutId, To: []string{"child1", "child2"},
+				}},
+				RootElements: []string{sutId},
+			},
+			expectedNodesLength: 3,
+			depth:               10,
+		},
+		{
+			//      mynode
+			//      /   \
+			//  child1  child2
+			//     |      |
+			// child1-1 child2-1
+			name: "four descendants two levels",
+			sut: &NodeList{
+				Nodes: []*Node{{Id: sutId}, {Id: "child1"}, {Id: "child2"}, {Id: "child1-1"}, {Id: "child2-1"}},
+				Edges: []*Edge{
+					{From: sutId, To: []string{"child1", "child2"}},
+					{From: "child1", To: []string{"child1-1"}},
+					{From: "child2", To: []string{"child2-1"}},
+				},
+				RootElements: []string{sutId},
+			},
+			expectedNodesLength: 5,
+			depth:               10,
+		},
+		{
+			//      mynode        <-- Depth 1
+			//      /   \
+			//  child1  child2    <-- Depth 2
+			//     |      |
+			// child1-1 child2-1  <-- Depth 3
+			name: "four descendants two levels, depth 2",
+			sut: &NodeList{
+				Nodes: []*Node{{Id: sutId}, {Id: "child1"}, {Id: "child2"}, {Id: "child1-1"}, {Id: "child2-1"}},
+				Edges: []*Edge{
+					{From: sutId, To: []string{"child1", "child2"}},
+					{From: "child1", To: []string{"child1-1"}},
+					{From: "child2", To: []string{"child2-1"}},
+				},
+				RootElements: []string{sutId},
+			},
+			expectedNodesLength: 3,
+			depth:               2,
+		},
+		{
+			//       root1    /-> root2
+			//          \    /       \
+			//       =mynode=      child3
+			//            |
+			//        child2-1
+			name: "mid node check we stop at root",
+			sut: &NodeList{
+				Nodes: []*Node{{Id: sutId}, {Id: "root1"}, {Id: "root2"}, {Id: "child2-1"}, {Id: "child3"}},
+				Edges: []*Edge{
+					{From: "root1", To: []string{sutId}},
+					{From: sutId, To: []string{"child2-1", "root2"}},
+					{From: "root2", To: []string{"child3"}},
+				},
+				RootElements: []string{"root1", "root2"},
+			},
+			expectedNodesLength: 3, // Must not contain root1 or child3
+			depth:               10,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			res := tc.sut.NodeDescendants(sutId, tc.depth)
+			require.NotNil(t, res)
+			require.Len(t, res.RootElements, 1)
+			require.Len(t, res.Nodes, tc.expectedNodesLength)
+		})
+	}
+}

--- a/pkg/sbom/nodelist.go
+++ b/pkg/sbom/nodelist.go
@@ -29,6 +29,14 @@ type purlIndex map[PackageURL][]*Node
 
 var ErrorMoreThanOneMatch = fmt.Errorf("More than one node matches")
 
+func NewNodeList() *NodeList {
+	return &NodeList{
+		Nodes:        []*Node{},
+		Edges:        []*Edge{},
+		RootElements: []string{},
+	}
+}
+
 // indexNodes returns an inverse dictionary with the IDs of the nodes
 func (nl *NodeList) indexNodes() nodeIndex {
 	ret := nodeIndex{}
@@ -151,6 +159,25 @@ func (nl *NodeList) cleanEdges() {
 
 func (nl *NodeList) AddEdge(e *Edge) {
 	nl.Edges = append(nl.Edges, e)
+}
+
+// AddRootNode adds a node to the nodelist and alos registers it to the
+// RootElements list.
+func (nl *NodeList) AddRootNode(n *Node) {
+	if n.Id == "" {
+		// TODO warn here
+		return
+	}
+
+	for _, id := range nl.RootElements {
+		if id == n.Id {
+			// TODO warn here
+			return
+		}
+	}
+
+	nl.AddNode(n)
+	nl.RootElements = append(nl.RootElements, n.Id)
 }
 
 func (nl *NodeList) AddNode(n *Node) {

--- a/pkg/sbom/nodelist.go
+++ b/pkg/sbom/nodelist.go
@@ -566,6 +566,46 @@ func (nl *NodeList) Equal(nl2 *NodeList) bool {
 	return cmp.Equal(nlNodes, nl2Nodes)
 }
 
+// RelateNodeAtID creates a relationship between Node n and an existing node
+// in the NodeList specified by nodeID. If the node (as looked up by ID) does not
+// not exist in the NodeList it will be added. If NodeID does not exist an error
+// will be returned.
+func (nl *NodeList) RelateNodeAtID(n *Node, nodeID string, edgeType Edge_Type) error {
+	// Check the node exists
+	nlIndex := nl.indexNodes()
+	nlEdges := nl.indexEdges()
+
+	if _, ok := nlIndex[nodeID]; !ok {
+		return fmt.Errorf("node with ID %s not found", nodeID)
+	}
+
+	// Check if we have edges matching
+	var edge *Edge
+	if _, ok := nlEdges[nodeID]; ok {
+		if _, ok2 := nlEdges[nodeID][edgeType]; ok2 {
+			edge = nlEdges[nodeID][edgeType][0]
+		}
+	}
+
+	if edge == nil {
+		edge = &Edge{
+			Type: edgeType,
+			From: nodeID,
+			To:   []string{n.Id},
+		}
+		nl.Edges = append(nl.Edges, edge)
+	} else {
+		// Perhaps we should filter these
+		edge.To = append(edge.To, n.Id)
+	}
+
+	// It the node does not exist in the nodelist, return
+	if _, ok := nlIndex[n.Id]; !ok {
+		nl.AddNode(n)
+	}
+	return nil
+}
+
 // RelateNodeListAtID relates the top level nodes in nl2 to the node with ID
 // nodeID using a relationship of type edgeType. Returns an error if nodeID cannot
 // be found in the graph. This function assumes that nodes in nl and nl2 having


### PR DESCRIPTION
This PR introduces new functions to the protobom graph API. It adds a few new capabilities to make life easier when working with SBOMs and new functionality.

New features:

-  `nodelist.NodeDescendants` is a new function that traverses the graph starting from a node and returns all linked nodes up to a set distance.
- `nodelist.AddRootNode` is the equivalent of `nodelist.AddNode` but it also registers the node as a root node.
- `nodelist.RelateNodeAtId` inserts a node into the graph by relating it to a specified node.

Quality of life improvements:

- `node.AddHash` is a convenience function to add hashes to nodes.
- We now have constructors for the protobom elements (eg `n := NewNode()` )

I've added tests for all new functions and simplified the readme with the new functions.

Signed-off-by: Adolfo Garcia Veytia (puerco) <puerco@chainguard.dev>

