### PR TITLE
Node diffing!

### DIFF
--- a/pkg/sbom/diff.go
+++ b/pkg/sbom/diff.go
@@ -1,0 +1,146 @@
+package sbom
+
+import (
+	"slices"
+
+	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// diffString takes compares s2 against s1. If they differ returns the value of
+// s2 in the removed return value. If s2 is blank, removed will have the original
+// value of s1. If the strings are differente count will be 1, zero if not.
+func diffString(s1, s2 string) (added, removed string, count int) {
+	if s1 == s2 {
+		return "", "", 0
+	}
+
+	if s2 == "" {
+		return "", s1, 1
+	}
+	return s2, "", 1
+}
+
+// diffDates takes two dates, comapres them and returns d2 in added if there is
+// a change, s1 in removed if d2 is nil. count will be 1 if there was a change.
+func diffDates(d1, d2 *timestamppb.Timestamp) (added, removed *timestamppb.Timestamp, count int) {
+	if (d1 != nil && d2 != nil && d1 != d2) || (d1 == nil && d2 != nil) {
+		return d2, nil, 1
+	} else if d1 != nil && d2 == nil {
+		return nil, d1, 1
+	}
+	return nil, nil, 0
+}
+
+func diffPersonList(list1, list2 []*Person) (added, removed []*Person, count int) {
+	added = []*Person{}
+	removed = []*Person{}
+
+	// Index persons
+	idx1 := map[string]*Person{}
+	idx2 := map[string]*Person{}
+
+	for _, p := range list1 {
+		idx1[p.flatString()] = p
+	}
+	for _, p := range list2 {
+		idx2[p.flatString()] = p
+	}
+
+	for _, p := range list2 {
+		if _, ok := idx1[p.flatString()]; !ok {
+			added = append(added, p)
+		}
+	}
+
+	for _, p := range list1 {
+		if _, ok := idx2[p.flatString()]; !ok {
+			removed = append(removed, p)
+		}
+	}
+	if len(added) > 0 || len(removed) > 0 {
+		count = 1
+	}
+	return added, removed, count
+}
+
+func diffExtRefList(list1, list2 []*ExternalReference) (added, removed []*ExternalReference, count int) {
+	added = []*ExternalReference{}
+	removed = []*ExternalReference{}
+
+	// Index persons
+	idx1 := map[string]*ExternalReference{}
+	idx2 := map[string]*ExternalReference{}
+
+	for _, er := range list1 {
+		idx1[er.flatString()] = er
+	}
+	for _, er := range list2 {
+		idx2[er.flatString()] = er
+	}
+
+	for _, er := range list2 {
+		if _, ok := idx1[er.flatString()]; !ok {
+			added = append(added, er)
+		}
+	}
+
+	for _, er := range list1 {
+		if _, ok := idx2[er.flatString()]; !ok {
+			removed = append(removed, er)
+		}
+	}
+
+	if len(added) > 0 || len(removed) > 0 {
+		count = 1
+	}
+	return added, removed, count
+}
+
+// diffIntStrMap(map1, )
+func diffIntStrMap(map1, map2 map[int32]string) (added, removed map[int32]string, count int) {
+	added = map[int32]string{}
+	removed = map[int32]string{}
+	for k, v2 := range map2 {
+		if v1, ok := map1[k]; ok {
+			if v2 != v1 {
+				added[k] = v2
+			}
+		} else {
+			added[k] = v2
+		}
+	}
+
+	for k, v1 := range map1 {
+		if _, ok := map2[k]; !ok {
+			removed[k] = v1
+		}
+	}
+
+	if len(added) > 0 || len(removed) > 0 {
+		count = 1
+	}
+	return added, removed, count
+}
+
+// diffStrSlice compares two
+func diffStrSlice(arr1, arr2 []string) (added, removed []string, count int) {
+	added = []string{}
+	removed = []string{}
+
+	for _, s := range arr2 {
+		if !slices.Contains(arr1, s) {
+			added = append(added, s)
+		}
+	}
+
+	for _, s := range arr1 {
+		if !slices.Contains(arr2, s) {
+			removed = append(removed, s)
+		}
+	}
+
+	if len(added) > 0 || len(removed) > 0 {
+		count = 1
+	}
+	return added, removed, count
+}

--- a/pkg/sbom/diff.go
+++ b/pkg/sbom/diff.go
@@ -6,6 +6,156 @@ import (
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 )
 
+type NodeDiff struct {
+	Added     *Node
+	Removed   *Node
+	DiffCount int
+}
+
+// Diff analyses a node and returns a a new node populated with all fields
+// that are different in n2 from n. If no changes are found, Diff returns nil
+func (n *Node) Diff(n2 *Node) *NodeDiff {
+	nd := NodeDiff{
+		Added:   NewNode(),
+		Removed: NewNode(),
+	}
+
+	a, r, c := diffString(n.Id, n2.Id)
+	nd.Added.Id = a
+	nd.Removed.Id = r
+	nd.DiffCount += c
+
+	if n.Type != n2.Type {
+		nd.Added.Type = n2.Type
+		nd.DiffCount++
+	}
+
+	a, r, c = diffString(n.Name, n2.Name)
+	nd.Added.Name = a
+	nd.Removed.Name = r
+	nd.DiffCount += c
+
+	a, r, c = diffString(n.Version, n2.Version)
+	nd.Added.Version = a
+	nd.Removed.Version = r
+	nd.DiffCount += c
+
+	a, r, c = diffString(n.FileName, n2.FileName)
+	nd.Added.FileName = a
+	nd.Removed.FileName = r
+	nd.DiffCount += c
+
+	a, r, c = diffString(n.UrlHome, n2.UrlHome)
+	nd.Added.UrlHome = a
+	nd.Removed.UrlHome = r
+	nd.DiffCount += c
+
+	a, r, c = diffString(n.UrlDownload, n2.UrlDownload)
+	nd.Added.UrlDownload = a
+	nd.Removed.UrlDownload = r
+	nd.DiffCount += c
+
+	a, r, c = diffString(n.LicenseConcluded, n2.LicenseConcluded)
+	nd.Added.LicenseConcluded = a
+	nd.Removed.LicenseConcluded = r
+	nd.DiffCount += c
+
+	a, r, c = diffString(n.LicenseComments, n2.LicenseComments)
+	nd.Added.LicenseComments = a
+	nd.Removed.LicenseComments = r
+	nd.DiffCount += c
+
+	a, r, c = diffString(n.Copyright, n2.Copyright)
+	nd.Added.Copyright = a
+	nd.Removed.Copyright = r
+	nd.DiffCount += c
+
+	a, r, c = diffString(n.SourceInfo, n2.SourceInfo)
+	nd.Added.SourceInfo = a
+	nd.Removed.SourceInfo = r
+	nd.DiffCount += c
+
+	a, r, c = diffString(n.PrimaryPurpose, n2.PrimaryPurpose)
+	nd.Added.PrimaryPurpose = a
+	nd.Removed.PrimaryPurpose = r
+	nd.DiffCount += c
+
+	a, r, c = diffString(n.Comment, n2.Comment)
+	nd.Added.Comment = a
+	nd.Removed.Comment = r
+	nd.DiffCount += c
+
+	a, r, c = diffString(n.Summary, n2.Summary)
+	nd.Added.Summary = a
+	nd.Removed.Summary = r
+	nd.DiffCount += c
+
+	a, r, c = diffString(n.Description, n2.Description)
+	nd.Added.Description = a
+	nd.Removed.Description = r
+	nd.DiffCount += c
+
+	addedD, removedD, count := diffDates(n.ReleaseDate, n2.ReleaseDate)
+	nd.Added.ReleaseDate = addedD
+	nd.Removed.ReleaseDate = removedD
+	nd.DiffCount += int(count)
+
+	addedD, removedD, count = diffDates(n.BuildDate, n2.BuildDate)
+	nd.Added.BuildDate = addedD
+	nd.Removed.BuildDate = removedD
+	nd.DiffCount += count
+
+	addedD, removedD, count = diffDates(n.ValidUntilDate, n2.ValidUntilDate)
+	nd.Added.ValidUntilDate = addedD
+	nd.Removed.ValidUntilDate = removedD
+	nd.DiffCount += count
+
+	added, removed, count := diffStrSlice(n.Licenses, n2.Licenses)
+	nd.Added.Licenses = added
+	nd.Removed.Licenses = removed
+	nd.DiffCount += count
+
+	added, removed, count = diffStrSlice(n.Attribution, n2.Attribution)
+	nd.Added.Attribution = added
+	nd.Removed.Attribution = removed
+	nd.DiffCount += count
+
+	added, removed, count = diffStrSlice(n.FileTypes, n2.FileTypes)
+	nd.Added.FileTypes = added
+	nd.Removed.FileTypes = removed
+	nd.DiffCount += count
+
+	addedP, removedP, count := diffPersonList(n.Suppliers, n2.Suppliers)
+	nd.Added.Suppliers = addedP
+	nd.Removed.Suppliers = removedP
+	nd.DiffCount += count
+
+	addedP, removedP, count = diffPersonList(n.Originators, n2.Originators)
+	nd.Added.Originators = addedP
+	nd.Removed.Originators = removedP
+	nd.DiffCount += count
+
+	addedER, removedER, count := diffExtRefList(n.ExternalReferences, n2.ExternalReferences)
+	nd.Added.ExternalReferences = addedER
+	nd.Removed.ExternalReferences = removedER
+	nd.DiffCount += count
+
+	addedM, removedM, count := diffIntStrMap(n.Identifiers, n2.Identifiers)
+	nd.Added.Identifiers = addedM
+	nd.Removed.Identifiers = removedM
+	nd.DiffCount += count
+
+	addedM, removedM, count = diffIntStrMap(n.Hashes, n2.Hashes)
+	nd.Added.Hashes = addedM
+	nd.Removed.Hashes = removedM
+	nd.DiffCount += count
+
+	if nd.DiffCount > 0 {
+		return &nd
+	}
+	return nil
+}
+
 // diffString takes compares s2 against s1. If they differ returns the value of
 // s2 in the removed return value. If s2 is blank, removed will have the original
 // value of s1. If the strings are differente count will be 1, zero if not.

--- a/pkg/sbom/diff.go
+++ b/pkg/sbom/diff.go
@@ -76,10 +76,10 @@ func (n *Node) Diff(n2 *Node) *NodeDiff {
 	nd.Removed.SourceInfo = r
 	nd.DiffCount += c
 
-	a, r, c = diffString(n.PrimaryPurpose, n2.PrimaryPurpose)
-	nd.Added.PrimaryPurpose = a
-	nd.Removed.PrimaryPurpose = r
-	nd.DiffCount += c
+	ap, rp, cp := diffPurposeSlice(n.PrimaryPurpose, n2.PrimaryPurpose)
+	nd.Added.PrimaryPurpose = ap
+	nd.Removed.PrimaryPurpose = rp
+	nd.DiffCount += cp
 
 	a, r, c = diffString(n.Comment, n2.Comment)
 	nd.Added.Comment = a
@@ -99,7 +99,7 @@ func (n *Node) Diff(n2 *Node) *NodeDiff {
 	addedD, removedD, count := diffDates(n.ReleaseDate, n2.ReleaseDate)
 	nd.Added.ReleaseDate = addedD
 	nd.Removed.ReleaseDate = removedD
-	nd.DiffCount += int(count)
+	nd.DiffCount += count
 
 	addedD, removedD, count = diffDates(n.BuildDate, n2.BuildDate)
 	nd.Added.BuildDate = addedD
@@ -157,9 +157,9 @@ func (n *Node) Diff(n2 *Node) *NodeDiff {
 	return nil
 }
 
-// diffString takes compares s2 against s1. If they differ returns the value of
+// diffString compares s2 against s1. If they differ returns the value of
 // s2 in the removed return value. If s2 is blank, removed will have the original
-// value of s1. If the strings are differente count will be 1, zero if not.
+// value of s1. If the strings are different count will be 1, zero if not.
 func diffString(s1, s2 string) (added, removed string, count int) {
 	if s1 == s2 {
 		return "", "", 0
@@ -171,7 +171,7 @@ func diffString(s1, s2 string) (added, removed string, count int) {
 	return s2, "", 1
 }
 
-// diffDates takes two dates, comapres them and returns d2 in added if there is
+// diffDates takes two dates, compares them and returns d2 in added if there is
 // a change, s1 in removed if d2 is nil. count will be 1 if there was a change.
 func diffDates(dt1, dt2 *timestamppb.Timestamp) (added, removed *timestamppb.Timestamp, count int) {
 	var d1, d2 *time.Time
@@ -282,10 +282,33 @@ func diffIntStrMap(map1, map2 map[int32]string) (added, removed map[int32]string
 	return added, removed, count
 }
 
-// diffStrSlice compares two
+// diffStrSlice compares two string slices and returns what was added and removed
 func diffStrSlice(arr1, arr2 []string) (added, removed []string, count int) {
 	added = []string{}
 	removed = []string{}
+
+	for _, s := range arr2 {
+		if !slices.Contains(arr1, s) {
+			added = append(added, s)
+		}
+	}
+
+	for _, s := range arr1 {
+		if !slices.Contains(arr2, s) {
+			removed = append(removed, s)
+		}
+	}
+
+	if len(added) > 0 || len(removed) > 0 {
+		count = 1
+	}
+	return added, removed, count
+}
+
+// diffPurposeSlice is a copy of diffString but handles lists of purposes instead of strings
+func diffPurposeSlice(arr1, arr2 []Purpose) (added, removed []Purpose, count int) {
+	added = []Purpose{}
+	removed = []Purpose{}
 
 	for _, s := range arr2 {
 		if !slices.Contains(arr1, s) {

--- a/pkg/sbom/diff.go
+++ b/pkg/sbom/diff.go
@@ -2,6 +2,7 @@ package sbom
 
 import (
 	"slices"
+	"time"
 
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -16,8 +17,8 @@ type NodeDiff struct {
 // that are different in n2 from n. If no changes are found, Diff returns nil
 func (n *Node) Diff(n2 *Node) *NodeDiff {
 	nd := NodeDiff{
-		Added:   NewNode(),
-		Removed: NewNode(),
+		Added:   &Node{},
+		Removed: &Node{},
 	}
 
 	a, r, c := diffString(n.Id, n2.Id)
@@ -172,11 +173,20 @@ func diffString(s1, s2 string) (added, removed string, count int) {
 
 // diffDates takes two dates, comapres them and returns d2 in added if there is
 // a change, s1 in removed if d2 is nil. count will be 1 if there was a change.
-func diffDates(d1, d2 *timestamppb.Timestamp) (added, removed *timestamppb.Timestamp, count int) {
-	if (d1 != nil && d2 != nil && d1 != d2) || (d1 == nil && d2 != nil) {
-		return d2, nil, 1
+func diffDates(dt1, dt2 *timestamppb.Timestamp) (added, removed *timestamppb.Timestamp, count int) {
+	var d1, d2 *time.Time
+	if dt1 != nil {
+		da1 := dt1.AsTime()
+		d1 = &da1
+	}
+	if dt2 != nil {
+		da2 := dt2.AsTime()
+		d2 = &da2
+	}
+	if (d1 != nil && d2 != nil && d1.Unix() != d2.Unix()) || (d1 == nil && d2 != nil) {
+		return dt2, nil, 1
 	} else if d1 != nil && d2 == nil {
-		return nil, d1, 1
+		return nil, dt1, 1
 	}
 	return nil, nil, 0
 }

--- a/pkg/sbom/diff_test.go
+++ b/pkg/sbom/diff_test.go
@@ -23,7 +23,7 @@ func TestNodeDiff(t *testing.T) {
 		LicenseComments:  "License inferred by an automated classifer",
 		Copyright:        "Copyright (c) 2023 The Protobom Authors",
 		SourceInfo:       "",
-		PrimaryPurpose:   "APPLICATION",
+		PrimaryPurpose:   []Purpose{Purpose_APPLICATION},
 		Comment:          "This a node to test node diffing",
 		Summary:          "A non existent node that serves as an example to diff",
 		Description:      "A non existent software package that can be used to test data",

--- a/pkg/sbom/diff_test.go
+++ b/pkg/sbom/diff_test.go
@@ -1,0 +1,361 @@
+package sbom
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TestDiffString(t *testing.T) {
+	for _, tc := range []struct {
+		name            string
+		sut1            string
+		sut2            string
+		expectedAdded   string
+		expectedRemoved string
+		expectedCount   int
+	}{
+		{
+			name:            "no change",
+			sut1:            "a",
+			sut2:            "a",
+			expectedAdded:   "",
+			expectedRemoved: "",
+			expectedCount:   0,
+		},
+		{
+			name:            "change",
+			sut1:            "",
+			sut2:            "a",
+			expectedAdded:   "a",
+			expectedRemoved: "",
+			expectedCount:   1,
+		},
+		{
+			name:            "remove",
+			sut1:            "a",
+			sut2:            "",
+			expectedAdded:   "",
+			expectedRemoved: "a",
+			expectedCount:   1,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			a, r, c := diffString(tc.sut1, tc.sut2)
+			require.Equal(t, tc.expectedAdded, a)
+			require.Equal(t, tc.expectedRemoved, r)
+			require.Equal(t, tc.expectedCount, c)
+		})
+	}
+}
+
+func TestDiffStrSlice(t *testing.T) {
+	for _, tc := range []struct {
+		name            string
+		sut1            []string
+		sut2            []string
+		expectedAdded   []string
+		expectedRemoved []string
+		expectedCount   int
+	}{
+		{
+			name:            "no change",
+			sut1:            []string{"a", "b"},
+			sut2:            []string{"a", "b"},
+			expectedAdded:   []string{},
+			expectedRemoved: []string{},
+			expectedCount:   0,
+		},
+		{
+			name:            "add to blank",
+			sut1:            []string{},
+			sut2:            []string{"a"},
+			expectedAdded:   []string{"a"},
+			expectedRemoved: []string{},
+			expectedCount:   1,
+		},
+		{
+			name:            "add to existing",
+			sut1:            []string{"a"},
+			sut2:            []string{"a", "b"},
+			expectedAdded:   []string{"b"},
+			expectedRemoved: []string{},
+			expectedCount:   1,
+		},
+		{
+			name:            "remove all",
+			sut1:            []string{"a", "b"},
+			sut2:            []string{},
+			expectedAdded:   []string{},
+			expectedRemoved: []string{"a", "b"},
+			expectedCount:   1,
+		},
+		{
+			name:            "remove one",
+			sut1:            []string{"a", "b"},
+			sut2:            []string{"b"},
+			expectedAdded:   []string{},
+			expectedRemoved: []string{"a"},
+			expectedCount:   1,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			a, r, c := diffStrSlice(tc.sut1, tc.sut2)
+			require.Equal(t, tc.expectedAdded, a)
+			require.Equal(t, tc.expectedRemoved, r)
+			require.Equal(t, tc.expectedCount, c)
+		})
+	}
+}
+
+func TestDiffDates(t *testing.T) {
+	t1 := timestamppb.New(time.Date(2023, 11, 15, 13, 30, 0, 0, time.UTC))
+	t2 := timestamppb.New(time.Date(2000, 1, 1, 13, 0, 0, 0, time.UTC))
+	for _, tc := range []struct {
+		name            string
+		sut1            *timestamppb.Timestamp
+		sut2            *timestamppb.Timestamp
+		expectedAdded   *timestamppb.Timestamp
+		expectedRemoved *timestamppb.Timestamp
+		expectedCount   int
+	}{
+		{
+			name:            "nochange",
+			sut1:            t1,
+			sut2:            t1,
+			expectedAdded:   nil,
+			expectedRemoved: nil,
+			expectedCount:   0,
+		},
+		{
+			name:            "nochange blank",
+			sut1:            nil,
+			sut2:            nil,
+			expectedAdded:   nil,
+			expectedRemoved: nil,
+			expectedCount:   0,
+		},
+		{
+			name:            "change",
+			sut1:            t1,
+			sut2:            t2,
+			expectedAdded:   t2,
+			expectedRemoved: nil,
+			expectedCount:   1,
+		},
+		{
+			name:            "remove",
+			sut1:            t2,
+			sut2:            nil,
+			expectedAdded:   nil,
+			expectedRemoved: t2,
+			expectedCount:   1,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			a, r, c := diffDates(tc.sut1, tc.sut2)
+			require.Equal(t, tc.expectedAdded, a)
+			require.Equal(t, tc.expectedRemoved, r)
+			require.Equal(t, tc.expectedCount, c)
+		})
+	}
+}
+
+func TestDiffPersonList(t *testing.T) {
+	p1 := &Person{
+		Name:  "Corelia Enterprises",
+		IsOrg: true,
+	}
+	p2 := &Person{
+		Name:  "Turbowind Enterprises",
+		IsOrg: true,
+	}
+	p3 := &Person{
+		Name: "Inky",
+	}
+	for _, tc := range []struct {
+		name            string
+		sut1            []*Person
+		sut2            []*Person
+		expectedAdded   []*Person
+		expectedRemoved []*Person
+		expectedCount   int
+	}{
+		{
+			name:            "no change",
+			sut1:            []*Person{p1, p2},
+			sut2:            []*Person{p1, p2},
+			expectedAdded:   []*Person{},
+			expectedRemoved: []*Person{},
+			expectedCount:   0,
+		},
+		{
+			name:            "add",
+			sut1:            []*Person{p1},
+			sut2:            []*Person{p1, p2},
+			expectedAdded:   []*Person{p2},
+			expectedRemoved: []*Person{},
+			expectedCount:   1,
+		},
+		{
+			name:            "remove",
+			sut1:            []*Person{p1, p2},
+			sut2:            []*Person{p1},
+			expectedAdded:   []*Person{},
+			expectedRemoved: []*Person{p2},
+			expectedCount:   1,
+		},
+		{
+			name:            "add and remove",
+			sut1:            []*Person{p1, p2},
+			sut2:            []*Person{p1, p3},
+			expectedAdded:   []*Person{p3},
+			expectedRemoved: []*Person{p2},
+			expectedCount:   1,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			a, r, c := diffPersonList(tc.sut1, tc.sut2)
+			require.Equal(t, tc.expectedAdded, a)
+			require.Equal(t, tc.expectedRemoved, r)
+			require.Equal(t, tc.expectedCount, c)
+		})
+	}
+}
+
+func TestDiffExtRefList(t *testing.T) {
+	er1 := &ExternalReference{
+		Url:  "https://example.com/",
+		Type: "URL",
+	}
+	er2 := &ExternalReference{
+		Url:  "https://example.net/",
+		Type: "URL",
+	}
+	er3 := &ExternalReference{
+		Url:  "https://example.org/",
+		Type: "URL",
+	}
+	for _, tc := range []struct {
+		name            string
+		sut1            []*ExternalReference
+		sut2            []*ExternalReference
+		expectedAdded   []*ExternalReference
+		expectedRemoved []*ExternalReference
+		expectedCount   int
+	}{
+		{
+			name:            "no change",
+			sut1:            []*ExternalReference{er1, er2},
+			sut2:            []*ExternalReference{er1, er2},
+			expectedAdded:   []*ExternalReference{},
+			expectedRemoved: []*ExternalReference{},
+			expectedCount:   0,
+		},
+		{
+			name:            "add",
+			sut1:            []*ExternalReference{er1},
+			sut2:            []*ExternalReference{er1, er2},
+			expectedAdded:   []*ExternalReference{er2},
+			expectedRemoved: []*ExternalReference{},
+			expectedCount:   1,
+		},
+		{
+			name:            "remove",
+			sut1:            []*ExternalReference{er1, er2},
+			sut2:            []*ExternalReference{er1},
+			expectedAdded:   []*ExternalReference{},
+			expectedRemoved: []*ExternalReference{er2},
+			expectedCount:   1,
+		},
+		{
+			name:            "add and remove",
+			sut1:            []*ExternalReference{er1, er2},
+			sut2:            []*ExternalReference{er1, er3},
+			expectedAdded:   []*ExternalReference{er3},
+			expectedRemoved: []*ExternalReference{er2},
+			expectedCount:   1,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			a, r, c := diffExtRefList(tc.sut1, tc.sut2)
+			require.Equal(t, tc.expectedAdded, a)
+			require.Equal(t, tc.expectedRemoved, r)
+			require.Equal(t, tc.expectedCount, c)
+		})
+	}
+}
+
+func TestDiffIntStrMap(t *testing.T) {
+	m1 := map[int32]string{
+		int32(HashAlgorithm_SHA1):   "68e6e3665b3010f0979089079d7f554c940e3aa8",
+		int32(HashAlgorithm_SHA256): "d02b22ab7fc76fe2a17e768b180bf5048889dbcae3a6d7e4a889a916848e5d11",
+	}
+	m2 := map[int32]string{
+		int32(HashAlgorithm_SHA1):   "68e6e3665b3010f0979089079d7f554c940e3aa8",
+		int32(HashAlgorithm_SHA256): "a8a20fe2e556080457d718930bfe1f423100952fdb3cffe9b1f0831be96fd85e",
+	}
+
+	for _, tc := range []struct {
+		name            string
+		sut1            map[int32]string
+		sut2            map[int32]string
+		expectedAdded   map[int32]string
+		expectedRemoved map[int32]string
+		expectedCount   int
+	}{
+		{
+			name:            "no change",
+			sut1:            m1,
+			sut2:            m1,
+			expectedAdded:   map[int32]string{},
+			expectedRemoved: map[int32]string{},
+			expectedCount:   0,
+		},
+		{
+			name: "change",
+			sut1: m1,
+			sut2: m2,
+			expectedAdded: map[int32]string{
+				int32(HashAlgorithm_SHA256): "a8a20fe2e556080457d718930bfe1f423100952fdb3cffe9b1f0831be96fd85e",
+			},
+			expectedRemoved: map[int32]string{},
+			expectedCount:   1,
+		},
+		{
+			name: "remove",
+			sut1: m1,
+			sut2: map[int32]string{
+				int32(HashAlgorithm_SHA256): "d02b22ab7fc76fe2a17e768b180bf5048889dbcae3a6d7e4a889a916848e5d11",
+			},
+			expectedAdded: map[int32]string{},
+			expectedRemoved: map[int32]string{
+				int32(HashAlgorithm_SHA1): "68e6e3665b3010f0979089079d7f554c940e3aa8",
+			},
+			expectedCount: 1,
+		},
+		{
+			name: "add and remove",
+			sut1: m1,
+			sut2: map[int32]string{
+				int32(HashAlgorithm_SHA256): "a8a20fe2e556080457d718930bfe1f423100952fdb3cffe9b1f0831be96fd85e",
+			},
+			expectedAdded: map[int32]string{
+				int32(HashAlgorithm_SHA256): "a8a20fe2e556080457d718930bfe1f423100952fdb3cffe9b1f0831be96fd85e",
+			},
+			expectedRemoved: map[int32]string{
+				int32(HashAlgorithm_SHA1): "68e6e3665b3010f0979089079d7f554c940e3aa8",
+			},
+			expectedCount: 1,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			a, r, c := diffIntStrMap(tc.sut1, tc.sut2)
+			require.Equal(t, tc.expectedAdded, a)
+			require.Equal(t, tc.expectedRemoved, r)
+			require.Equal(t, tc.expectedCount, c)
+		})
+	}
+}


### PR DESCRIPTION
This PR is the first of a series to build diffing capabilities into the protobom core. This PR starts with diffing support in the node. To compare two nodes, you simply call the new node.Diff method and pass it a second node to compare:

```golang
diff := node1.Diff(node2)
```

The result is a new simple structure called `NodeDiff` that captures in two nodes data from fields that were changed or added, data that was removed and the number of changes:

```golang
type NodeDiff struct {
	Added     *Node
	Removed   *Node
	DiffCount int
}
```

I've added some tests to the diff function that verify the integration with some of the helper functions, they can be improved and we should probably create a conformance framework to test diffing.

Note: Needs #140 to run

Signed-off-by: Adolfo Garcia Veytia (puerco) <puerco@chainguard.dev> 