### PR TITLE
chore: remove wey from maintainers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -18,4 +18,4 @@
 
 # owner(s) will be requested for a review.
 
-*       @wey-chiang @bardenstein @puerco @dn-scribe @mikhailswift @smarabbit @jspeed-meyers @veramine @manifestori
+-       @bardenstein @puerco @dn-scribe @mikhailswift @smarabbit @jspeed-meyers @veramine @manifestori


### PR DESCRIPTION
wey no longer works for Manifest Cyber, therefore, he is no longer a maintainer≈
