### PR TITLE
Bump CDX libraries to 0.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/bom-squad/protobom
 go 1.21
 
 require (
-	github.com/CycloneDX/cyclonedx-go v0.7.2
+	github.com/CycloneDX/cyclonedx-go v0.8.0
 	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.5.0
 	github.com/maxbrunsfeld/counterfeiter/v6 v6.7.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/CycloneDX/cyclonedx-go v0.7.2 h1:kKQ0t1dPOlugSIYVOMiMtFqeXI2wp/f5DBIdfux8gnQ=
-github.com/CycloneDX/cyclonedx-go v0.7.2/go.mod h1:K2bA+324+Og0X84fA8HhN2X066K7Bxz4rpMQ4ZhjtSk=
+github.com/CycloneDX/cyclonedx-go v0.8.0 h1:FyWVj6x6hoJrui5uRQdYZcSievw3Z32Z88uYzG/0D6M=
+github.com/CycloneDX/cyclonedx-go v0.8.0/go.mod h1:K2bA+324+Og0X84fA8HhN2X066K7Bxz4rpMQ4ZhjtSk=
 github.com/anchore/go-struct-converter v0.0.0-20221118182256-c68fdcfa2092/go.mod h1:rYqSE9HbjzpHTI74vwPvae4ZVYZd1lue2ta6xHPdblA=
 github.com/anchore/go-struct-converter v0.0.0-20230627203149-c72ef8859ca9 h1:6COpXWpHbhWM1wgcQN95TdsmrLTba8KQfPgImBXzkjA=
 github.com/anchore/go-struct-converter v0.0.0-20230627203149-c72ef8859ca9/go.mod h1:rYqSE9HbjzpHTI74vwPvae4ZVYZd1lue2ta6xHPdblA=

--- a/pkg/native/serializers/serializer_cdx.go
+++ b/pkg/native/serializers/serializer_cdx.go
@@ -120,15 +120,16 @@ func (s *CDX) Serialize(bom *sbom.Document, _ *native.SerializeOptions, _ interf
 	}
 
 	if bom.Metadata != nil && len(bom.GetMetadata().GetTools()) > 0 {
-		var tools []cdx.Tool
+		var tools []cdx.Tool //nolint:staticcheck
 		for _, bomtool := range bom.GetMetadata().GetTools() {
-			tools = append(tools, cdx.Tool{
-				Vendor:  bomtool.Vendor,
+			tools = append(tools, cdx.Tool{ //nolint:staticcheck // Tool is needed for older cdx versions
 				Name:    bomtool.Name,
 				Version: bomtool.Version,
 			})
 		}
-		metadata.Tools = &tools
+		metadata.Tools = &cdx.ToolsChoice{
+			Tools: &tools,
+		}
 	}
 
 	if bom.Metadata != nil && len(bom.GetMetadata().GetName()) > 0 {


### PR DESCRIPTION
This PR updates the cycloneDX libraries to v0.8.0. It only fixes the serializer to use the new ToolChoice struct introduced in the latest version. It does not yet support the new component-based tool.

/cc @manifestori @veramine 

Signed-off-by: Adolfo Garcia Veytia (puerco) <puerco@chainguard.dev>