### PR TITLE
Add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,25 @@
+# Reporting Security Issues
+
+To report as security issue in the protobom family of projects, please use
+the GitHub
+[private vulnerability reporting](https://github.com/bom-squad/protobom/security/advisories/new)
+tool. The maintainers will give your report the maximum priority possible
+and will try to triage it right away. We will also credit you if protobom choses
+to issue a formal advisory.
+
+### When Should I Report a Vulnerability?
+
+* You found a vulnerability in the protobom code.
+* You found a vulnerability in one of the protobom dependencies that affects
+the project that has not been patched yet.
+
+### When Should I NOT Report a Vulnerability?
+
+* You found a bug or malfunction in the protobom code (not security related).
+* You want to add a feature to protobom.
+* You found an insecure use of the protobom libraries or tools in another project.
+
+## Contacting Us
+
+To contact the project maintainers to discuss security related issues, please
+email one or more of the maintainers listed in the [CODEOWNERS](CODEOWNERS) file.


### PR DESCRIPTION
This PR adds a basic security,md file to the repository. The missing file was highlighted during the OpenSSF TAC vote.


Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>
