### PR TITLE
Suggestion/node list api copy

### DIFF
--- a/pkg/sbom/nodelist.go
+++ b/pkg/sbom/nodelist.go
@@ -268,12 +268,7 @@ func copyEdgeList(original []*Edge) []*Edge {
 
 // Copy returns a duplicate of the NodeList.
 func (nl *NodeList) Copy() *NodeList {
-	nlo := &NodeList{
-		// 2DO not sure what to do.
-		// state:         nl.state,
-		// sizeCache:     nl.sizeCache,
-		// unknownFields: nl.unknownFields,
-	}
+	nlo := &NodeList{}
 
 	for _, n := range nl.Nodes {
 		nlo.Nodes = append(nlo.Nodes, n.Copy())

--- a/pkg/sbom/nodelist.go
+++ b/pkg/sbom/nodelist.go
@@ -266,6 +266,27 @@ func copyEdgeList(original []*Edge) []*Edge {
 	return nodeCopy
 }
 
+// Copy returns a duplicate of the NodeList.
+func (nl *NodeList) Copy() *NodeList {
+	nlo := &NodeList{
+		// 2DO not sure what to do.
+		// state:         nl.state,
+		// sizeCache:     nl.sizeCache,
+		// unknownFields: nl.unknownFields,
+	}
+
+	for _, n := range nl.Nodes {
+		nlo.Nodes = append(nlo.Nodes, n.Copy())
+	}
+	for _, e := range nl.Edges {
+		nlo.Edges = append(nlo.Edges, e.Copy())
+	}
+
+	nlo.RootElements = append(nlo.RootElements, nl.RootElements...)
+
+	return nlo
+}
+
 // Intersect returns a new NodeList that represents the intersection
 // of nodes and their relationships between nl and nl2.
 // The resulting NodeList contains common nodes and edges copied from nl, and updates them with data from nl2.

--- a/pkg/sbom/nodelist_test.go
+++ b/pkg/sbom/nodelist_test.go
@@ -1275,3 +1275,43 @@ func TestRelateNodeAtId(t *testing.T) {
 		})
 	}
 }
+
+func TestNodeListCopy(t *testing.T) {
+	for _, tc := range []struct {
+		original *NodeList
+	}{
+		{
+			original: &NodeList{
+				Nodes: []*Node{
+					{Id: "test1"},
+					{Id: "test2"},
+				},
+				Edges: []*Edge{
+					{From: "test1", Type: Edge_contains, To: []string{"test2"}},
+				},
+			},
+		},
+		{
+			original: &NodeList{
+				Nodes: []*Node{
+					{Id: "root1"}, {Id: "root2"}, {Id: "descendant"},
+				},
+				Edges: []*Edge{
+					{From: "root2", To: []string{"descendant"}},
+					{From: "descendant", To: []string{"root1"}},
+				},
+				RootElements: []string{"root1", "root2"},
+			},
+		},
+		{
+			original: &NodeList{
+				Nodes:        []*Node{},
+				Edges:        []*Edge{},
+				RootElements: []string{"root1", "root2"},
+			},
+		},
+	} {
+		copied := tc.original.Copy()
+		require.True(t, tc.original.Equal(copied), "equal copied nodelist", tc.original, copied)
+	}
+}


### PR DESCRIPTION
This pull request proposes the addition of a Copy API to the NodeList structure. During my experimentation with unit tests related to the NodeList, I identified a need for a method to efficiently copy instances of this structure.

**Changes Introduced:**
Added a Copy method to the NodeList structure.