### PR TITLE
upgrade to use go1.22 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,23 @@
 # https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 version: 2
 updates:
-  - package-ecosystem: "gomod"
+  - package-ecosystem: gomod
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      gomod:
+        update-types:
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      actions:
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/go-build-and-test.yml
+++ b/.github/workflows/go-build-and-test.yml
@@ -15,7 +15,8 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
       with:
-        go-version: '1.21'
+        go-version: '1.22'
+        check-latest: true
 
     - name: Verify proto generated code
       run: |

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,4 +1,5 @@
 name: golangci-lint
+
 on:
   pull_request:
     branches:
@@ -13,9 +14,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+
       - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
         with:
-          go-version: '1.21'
+          go-version: '1.22'
+          check-latest: true
           cache: false
+
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v3.6.0
+        uses: golangci/golangci-lint-action@3cfe3a4abbb849e10058ce4af15d205b6da42804 # v4.0.0
+        with:
+          version: v1.57

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,4 +23,3 @@ jobs:
         uses: kubernetes-sigs/release-actions/publish-release@ef6d340ddd115f41dc26c18893b41d9c79cdc7d2 # main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        


### PR DESCRIPTION
- upgrade to use go1.22 
- update dependabot config to add groups and github actions 