### PR TITLE
Fix data race in cdx serializer.

### DIFF
--- a/pkg/native/serializers/serializer_cdx.go
+++ b/pkg/native/serializers/serializer_cdx.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	cdx "github.com/CycloneDX/cyclonedx-go"
@@ -22,7 +23,10 @@ var _ native.Serializer = &CDX{}
 // Precompiled regex for serialNumber validation
 const serialNumberPattern = `^urn:uuid:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`
 
-var serialNumberRegex *regexp.Regexp
+var (
+	serialNumberRegex     *regexp.Regexp
+	serialNumberRegexInit sync.Once
+)
 
 type (
 	CDX struct {
@@ -198,7 +202,9 @@ func buildDependencies(nl *sbom.NodeList, components map[string]*cdx.Component) 
 // isValidCycloneDXSerialNumber validates serial id against regex pattern
 func isValidCycloneDXSerialNumberFormat(serial string) bool {
 	if serialNumberRegex == nil {
-		serialNumberRegex = regexp.MustCompile(serialNumberPattern)
+		serialNumberRegexInit.Do(func() {
+			serialNumberRegex = regexp.MustCompile(serialNumberPattern)
+		})
 	}
 	return serialNumberRegex.MatchString(serial)
 }


### PR DESCRIPTION
While it's not necessarily a bug since it'll evaluate to the same value, the way that the serialNumberRegex is initialized makes the race detector grumpy because of how concurrent calls can end up writing over the same value:

```
  WARNING: DATA RACE
  Write at 0x00000882f3c0 by goroutine 5382:
    github.com/protobom/protobom/pkg/native/serializers.isValidCycloneDXSerialNumberFormat()
        /home/runner/go/pkg/mod/github.com/protobom/protobom@v0.5.4/pkg/native/serializers/serializer_cdx.go:201 +0x66
    github.com/protobom/protobom/pkg/native/serializers.(*CDX).Serialize()
        /home/runner/go/pkg/mod/github.com/protobom/protobom@v0.5.4/pkg/native/serializers/serializer_cdx.go:81 +0x41c
    github.com/protobom/protobom/pkg/writer.(*Writer).WriteStreamWithOptions()
        /home/runner/go/pkg/mod/github.com/protobom/protobom@v0.5.4/pkg/writer/writer.go:115 +0x287
```

This is because the read can happen in 2 goroutines then individual writes occur. Even though this is technically safe because they'll set the same value, the race detector gets mad.

This uses a sync.Once to preserve the lazy load behavior. Alternatively we could move the MustCompile call into the var itself.