### PR TITLE
Actually fix cdx regex init data race

### DIFF
--- a/pkg/native/serializers/serializer_cdx.go
+++ b/pkg/native/serializers/serializer_cdx.go
@@ -201,11 +201,9 @@ func buildDependencies(nl *sbom.NodeList, components map[string]*cdx.Component) 
 
 // isValidCycloneDXSerialNumber validates serial id against regex pattern
 func isValidCycloneDXSerialNumberFormat(serial string) bool {
-	if serialNumberRegex == nil {
-		serialNumberRegexInit.Do(func() {
-			serialNumberRegex = regexp.MustCompile(serialNumberPattern)
-		})
-	}
+	serialNumberRegexInit.Do(func() {
+		serialNumberRegex = regexp.MustCompile(serialNumberPattern)
+	})
 	return serialNumberRegex.MatchString(serial)
 }
 


### PR DESCRIPTION
This is a follow up to https://github.com/protobom/protobom/pull/386, which didn't actually fix the problem w.r.t. the race detector because of the unsynchronized read.

This removes the read, since it doesn't really make a difference for the init once behavior.