### PR TITLE
Fix link and formatting in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 # protobom
 
 <img align="right" width="75" height="75" src="docs/images/OpenSSF_StagesBadges_sandbox.svg" alt="OpenSSF Sandbox Badge">
+
 `protobom` is a [protocol buffers](https://protobuf.dev/getting-started/)
 representation of SBOM data able to ingest documents in modern
 [SPDX](https://spdx.dev/) and [CycloneDX](https://cyclonedx.org/) versions
@@ -78,7 +79,7 @@ func main() {
 
 ### Example 3:  Generate an SBOM document programmatically
 
-Developers can use the `protobom` library to generate SBOM documents based on the content of a separate SBOM document, as shown by the sbom-convert project (https://github.com/protobom/sbom-convert).
+Developers can use the `protobom` library to generate SBOM documents based on the content of a separate SBOM document, as shown by the [sbom-convert](https://github.com/protobom/sbom-convert) project.
 
 However, the `protobom` intermediate representation could also be used to create a new SBOM document.  Developers could create a new `protobom` document and use the Go programming language to populate the fields needed in the SBOM document.  The developer would then create a new Writer to define where the SBOM should be written, and to which format the SBOM should be written passing in the programmatically-defined SBOM structure.  The protobom v0.2.0 release includes six registered serializer formats for Writer.New(): SPDX23JSON, CDX12JSON, CDX13JSON, CDX14JSON, CDX15JSON, and CDX16JSON.
 


### PR DESCRIPTION
Updated README's first paragraph to make the links appear properly.

Currently the links don't work:

<img width="765" height="109" alt="Screenshot 2569-02-24 at 15 50 00" src="https://github.com/user-attachments/assets/197b98fd-2e7f-46d2-b19f-ff26be0c6815" />

The immediately img tag in the first line makes the Markdown confused and doesn't render "protocol buffers", "SPDX", and "CyloneDX" links properly. Fix by insert one blank line between the img and the text.


