### PR TITLE
Preliminary CycloneDX 1.7 Support

### DIFF
--- a/pkg/formats/cyclonedx/cyclonedx.go
+++ b/pkg/formats/cyclonedx/cyclonedx.go
@@ -25,6 +25,11 @@ func ParseVersion(version string) (cyclonedx.SpecVersion, error) {
 		specVersion = cyclonedx.SpecVersion1_5
 	case "1.6":
 		specVersion = cyclonedx.SpecVersion1_6
+	case "1.7":
+		// cyclonedx-go does not yet support 1.7. Since 1.7 is additive
+		// and protobom does not need any of the new fields, we parse
+		// and serialize 1.7 documents using the 1.6 spec version.
+		specVersion = cyclonedx.SpecVersion1_6
 	default:
 		return specVersion, fmt.Errorf("unsupported CDX version %s", version)
 	}

--- a/pkg/formats/formats.go
+++ b/pkg/formats/formats.go
@@ -24,6 +24,7 @@ const (
 	CDX14JSON  = Format("application/vnd.cyclonedx+json;version=1.4")
 	CDX15JSON  = Format("application/vnd.cyclonedx+json;version=1.5")
 	CDX16JSON  = Format("application/vnd.cyclonedx+json;version=1.6")
+	CDX17JSON  = Format("application/vnd.cyclonedx+json;version=1.7")
 	CDXFORMAT  = "cyclonedx"
 	SPDXFORMAT = "spdx"
 )
@@ -32,7 +33,7 @@ type Document interface{}
 
 var (
 	ListFormats = []Format{CDXFORMAT, SPDXFORMAT}
-	List        = []Format{SPDX23TV, SPDX23JSON, SPDX22TV, SPDX22JSON, CDX14JSON, CDX15JSON, CDX16JSON}
+	List        = []Format{SPDX23TV, SPDX23JSON, SPDX22TV, SPDX22JSON, CDX14JSON, CDX15JSON, CDX16JSON, CDX17JSON}
 )
 
 // Version returns the version of the format

--- a/pkg/formats/sniffer.go
+++ b/pkg/formats/sniffer.go
@@ -74,8 +74,10 @@ func (fs *Sniffer) SniffReader(f io.ReadSeeker) (Format, error) {
 				return CDX15JSON, nil
 			case "1.6":
 				return CDX16JSON, nil
+			case "1.7":
+				return CDX17JSON, nil
 			default:
-				// JSON + BomFormat CycloneDX but specVersion not 1.3, 1.4, 1.5, or 1.6
+				// JSON + BomFormat CycloneDX but specVersion not 1.3, 1.4, 1.5, 1.6, or 1.7
 				return "", fmt.Errorf("unknown SBOM format")
 			}
 		} else {

--- a/pkg/formats/sniffer_test.go
+++ b/pkg/formats/sniffer_test.go
@@ -66,6 +66,13 @@ func TestSniffReader(t *testing.T) {
 			encoding:   "json",
 		},
 		{
+			filename:   "testdata/minimal.cdx.1.7.json",
+			mustError:  false,
+			version:    "1.7",
+			formatType: "cyclonedx",
+			encoding:   "json",
+		},
+		{
 			filename:  "testdata/syft.json",
 			mustError: true,
 		},

--- a/pkg/formats/testdata/minimal.cdx.1.7.json
+++ b/pkg/formats/testdata/minimal.cdx.1.7.json
@@ -1,0 +1,1 @@
+{"bomFormat":"CycloneDX","specVersion":"1.7","version":1,"serialNumber":"urn:uuid:b35ea91e-91c2-40ae-97fe-c015a4fd8790","metadata":{}}

--- a/pkg/native/serializers/serializer_cdx.go
+++ b/pkg/native/serializers/serializer_cdx.go
@@ -1,6 +1,7 @@
 package serializers
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -501,16 +502,43 @@ func (s *CDX) Render(doc interface{}, wr io.Writer, o *native.RenderOptions, _ i
 		return fmt.Errorf("getting CDX encoding: %w", err)
 	}
 
-	encoder := cdx.NewBOMEncoder(wr, encoding)
-	encoder.SetPretty(true)
-
 	cdxdoc, ok := doc.(*cdx.BOM)
 	if !ok {
 		return errors.New("document is not a cyclonedx bom")
 	}
 
+	// When the requested version differs from the library version used for
+	// encoding (e.g. 1.7 encoded as 1.6 because cyclonedx-go lacks native
+	// support), we encode to a buffer and patch the specVersion field before
+	// writing to the final output.
+	if s.version == version.String() {
+		encoder := cdx.NewBOMEncoder(wr, encoding)
+		encoder.SetPretty(true)
+
+		if err := encoder.EncodeVersion(cdxdoc, version); err != nil {
+			return fmt.Errorf("encoding sbom to stream: %w", err)
+		}
+
+		return nil
+	}
+
+	var buf bytes.Buffer
+	encoder := cdx.NewBOMEncoder(&buf, encoding)
+	encoder.SetPretty(true)
+
 	if err := encoder.EncodeVersion(cdxdoc, version); err != nil {
 		return fmt.Errorf("encoding sbom to stream: %w", err)
+	}
+
+	patched := bytes.Replace(
+		buf.Bytes(),
+		[]byte(fmt.Sprintf(`"specVersion": "%s"`, version)),
+		[]byte(fmt.Sprintf(`"specVersion": "%s"`, s.version)),
+		1,
+	)
+
+	if _, err := wr.Write(patched); err != nil {
+		return fmt.Errorf("writing patched sbom to stream: %w", err)
 	}
 
 	return nil

--- a/pkg/reader/reader.go
+++ b/pkg/reader/reader.go
@@ -49,6 +49,7 @@ func init() {
 	unserializers[formats.CDX14JSON] = drivers.NewCDX("1.4", formats.JSON)
 	unserializers[formats.CDX15JSON] = drivers.NewCDX("1.5", formats.JSON)
 	unserializers[formats.CDX16JSON] = drivers.NewCDX("1.6", formats.JSON)
+	unserializers[formats.CDX17JSON] = drivers.NewCDX("1.7", formats.JSON)
 	unserializers[formats.SPDX23JSON] = drivers.NewSPDX23()
 	regMtx.Unlock()
 }

--- a/pkg/writer/writer.go
+++ b/pkg/writer/writer.go
@@ -55,6 +55,7 @@ func ensureSerializersInitialized() {
 		serializers.Store(formats.CDX14JSON, drivers.NewCDX("1.4", formats.JSON))
 		serializers.Store(formats.CDX15JSON, drivers.NewCDX("1.5", formats.JSON))
 		serializers.Store(formats.CDX16JSON, drivers.NewCDX("1.6", formats.JSON))
+		serializers.Store(formats.CDX17JSON, drivers.NewCDX("1.7", formats.JSON))
 		serializers.Store(formats.SPDX23JSON, drivers.NewSPDX23())
 	})
 }


### PR DESCRIPTION
This PR adds preliminary CycloneDX 1.7 support to protobom. As the upstream library has not released 1.7 support yet, we essentially piggy back on 1.6 to parse the documents as the changes we may pick up from 1.7 seem to be minimal.

To support 1.7 essentially we:

- Read them as if they were 1.6 (most 1.7 features are not in scope for protobom)
- Serialize 1.6 to a buffer and replace the version (again, as protobom does no use the new features in 1.7)

Added a simple test case. This is a temporary patch to be replaced once 1.7 support in the upstream library rolls out.

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@carabiner.dev>