### PR TITLE
Add support for filter out dep types

### DIFF
--- a/pkg/sbom/nodelist.go
+++ b/pkg/sbom/nodelist.go
@@ -220,8 +220,8 @@ func (nl *NodeList) AddNode(n *Node) {
 func (nl *NodeList) Add(nl2 *NodeList) {
 	existingNodes := nl.indexNodes()
 	for i := range nl2.Nodes {
-		if n, ok := existingNodes[nl2.Nodes[i].Id]; ok {
-			existingNodes[nl2.Nodes[i].Id].Augment(n)
+		if _, ok := existingNodes[nl2.Nodes[i].Id]; ok {
+			existingNodes[nl2.Nodes[i].Id].Augment(nl2.Nodes[i])
 		} else {
 			nl.Nodes = append(nl.Nodes, nl2.Nodes[i])
 		}

--- a/pkg/sbom/nodelist.go
+++ b/pkg/sbom/nodelist.go
@@ -205,7 +205,7 @@ func (nl *NodeList) AddRootNode(n *Node) {
 	nl.RootElements = append(nl.RootElements, n.Id)
 }
 
-// AddEdge adds a new node to the Node List.
+// AddNode adds a new node to the Node List.
 func (nl *NodeList) AddNode(n *Node) {
 	nl.Nodes = append(nl.Nodes, n)
 }
@@ -618,9 +618,11 @@ func (nl *NodeList) Equal(nl2 *NodeList) bool {
 		return false
 	}
 
-	// Compare the flattened rootElements list
-	r1 := nl.RootElements
-	r2 := nl2.RootElements
+	// Compare the flattened rootElements list (copy to avoid mutating originals)
+	r1 := make([]string, len(nl.RootElements))
+	copy(r1, nl.RootElements)
+	r2 := make([]string, len(nl2.RootElements))
+	copy(r2, nl2.RootElements)
 	sort.Strings(r1)
 	sort.Strings(r2)
 	if !reflect.DeepEqual(r1, r2) {

--- a/pkg/sbom/nodelist.go
+++ b/pkg/sbom/nodelist.go
@@ -256,6 +256,59 @@ func (nl *NodeList) RemoveNodes(ids []string) {
 	nl.cleanEdges()
 }
 
+// RemoveNodesByEdgeType removes nodes and edges associated with the specified
+// edge types. For nodes that are ONLY reachable via the specified edge types,
+// the nodes are removed entirely. For nodes that are reachable via both
+// specified and non-specified edge types, only the edges of the specified
+// types are removed while the nodes are kept.
+func (nl *NodeList) RemoveNodesByEdgeType(edgeTypes ...Edge_Type) {
+	if len(edgeTypes) == 0 {
+		return
+	}
+
+	// Build a set of edge types to remove
+	removeTypes := make(map[Edge_Type]struct{}, len(edgeTypes))
+	for _, t := range edgeTypes {
+		removeTypes[t] = struct{}{}
+	}
+
+	// Track which node IDs are targets of excluded vs included edges
+	includedTargets := make(map[string]struct{})
+	excludedTargets := make(map[string]struct{})
+
+	for _, edge := range nl.Edges {
+		_, isExcluded := removeTypes[edge.Type]
+		for _, toID := range edge.To {
+			if isExcluded {
+				excludedTargets[toID] = struct{}{}
+			} else {
+				includedTargets[toID] = struct{}{}
+			}
+		}
+	}
+
+	// Remove edges of the specified types
+	var keptEdges []*Edge
+	for _, edge := range nl.Edges {
+		if _, remove := removeTypes[edge.Type]; !remove {
+			keptEdges = append(keptEdges, edge)
+		}
+	}
+	nl.Edges = keptEdges
+
+	// Remove nodes that were only reachable via the excluded edge types
+	var toRemove []string
+	for id := range excludedTargets {
+		if _, kept := includedTargets[id]; !kept {
+			toRemove = append(toRemove, id)
+		}
+	}
+
+	if len(toRemove) > 0 {
+		nl.RemoveNodes(toRemove)
+	}
+}
+
 // GetEdgeByType returns the first edge of the specified type (t) originating from the given node ID (fromElement).
 // If no such edge is found, it returns nil.
 func (nl *NodeList) GetEdgeByType(fromElement string, t Edge_Type) *Edge {

--- a/pkg/sbom/nodelist.go
+++ b/pkg/sbom/nodelist.go
@@ -237,7 +237,8 @@ func (nl *NodeList) Add(nl2 *NodeList) {
 }
 
 // RemoveNodes removes nodes with specified IDs from the NodeList.
-// It also removes corresponding edges connected to the removed nodes.
+// It also removes corresponding edges connected to the removed nodes
+// and cleans up RootElements references.
 func (nl *NodeList) RemoveNodes(ids []string) {
 	// build an inverse dict of the IDs
 	idDict := map[string]struct{}{}
@@ -253,6 +254,16 @@ func (nl *NodeList) RemoveNodes(ids []string) {
 	}
 
 	nl.Nodes = newNodeList
+
+	// Remove from RootElements too
+	newRoots := make([]string, 0, len(nl.RootElements))
+	for _, id := range nl.RootElements {
+		if _, ok := idDict[id]; !ok {
+			newRoots = append(newRoots, id)
+		}
+	}
+	nl.RootElements = newRoots
+
 	nl.cleanEdges()
 }
 

--- a/pkg/sbom/nodelist.go
+++ b/pkg/sbom/nodelist.go
@@ -190,8 +190,9 @@ func (nl *NodeList) MergeEdges(es []*Edge) {
 	}
 }
 
-// AddRootNode adds a node to the NodeList and registers it as a Root Elements.
+// AddRootNode adds a node to the NodeList and registers it as a Root Element.
 // More than one root element can be added to the NodeList.
+// If the node already exists (by ID), it is not added again.
 func (nl *NodeList) AddRootNode(n *Node) {
 	if n.Id == "" {
 		n.Id = NewNodeIdentifier("auto", fmt.Sprintf("%s@%s", n.Name, n.Version))
@@ -201,7 +202,10 @@ func (nl *NodeList) AddRootNode(n *Node) {
 		return
 	}
 
-	nl.AddNode(n)
+	// Only add the node if it doesn't already exist
+	if nl.GetNodeByID(n.Id) == nil {
+		nl.AddNode(n)
+	}
 	nl.RootElements = append(nl.RootElements, n.Id)
 }
 

--- a/pkg/sbom/nodelist_test.go
+++ b/pkg/sbom/nodelist_test.go
@@ -137,6 +137,110 @@ func TestRemoveNodes(t *testing.T) {
 	}
 }
 
+func TestRemoveNodesByEdgeType(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		sut       *NodeList
+		types     []Edge_Type
+		wantNodes []string
+		wantEdges int
+	}{
+		{
+			name: "remove dev-only node",
+			sut: &NodeList{
+				Nodes: []*Node{
+					{Id: "root"}, {Id: "prod"}, {Id: "dev"},
+				},
+				Edges: []*Edge{
+					{Type: Edge_dependsOn, From: "root", To: []string{"prod"}},
+					{Type: Edge_devDependency, From: "root", To: []string{"dev"}},
+				},
+				RootElements: []string{"root"},
+			},
+			types:     []Edge_Type{Edge_devDependency},
+			wantNodes: []string{"root", "prod"},
+			wantEdges: 1,
+		},
+		{
+			name: "keep node reachable by both edge types",
+			sut: &NodeList{
+				Nodes: []*Node{
+					{Id: "root"}, {Id: "shared"},
+				},
+				Edges: []*Edge{
+					{Type: Edge_dependsOn, From: "root", To: []string{"shared"}},
+					{Type: Edge_devDependency, From: "root", To: []string{"shared"}},
+				},
+				RootElements: []string{"root"},
+			},
+			types:     []Edge_Type{Edge_devDependency},
+			wantNodes: []string{"root", "shared"},
+			wantEdges: 1,
+		},
+		{
+			name: "remove multiple edge types",
+			sut: &NodeList{
+				Nodes: []*Node{
+					{Id: "root"}, {Id: "prod"}, {Id: "dev"}, {Id: "build"},
+				},
+				Edges: []*Edge{
+					{Type: Edge_dependsOn, From: "root", To: []string{"prod"}},
+					{Type: Edge_devDependency, From: "root", To: []string{"dev"}},
+					{Type: Edge_buildDependency, From: "root", To: []string{"build"}},
+				},
+				RootElements: []string{"root"},
+			},
+			types:     []Edge_Type{Edge_devDependency, Edge_buildDependency},
+			wantNodes: []string{"root", "prod"},
+			wantEdges: 1,
+		},
+		{
+			name: "no types specified does nothing",
+			sut: &NodeList{
+				Nodes: []*Node{
+					{Id: "root"}, {Id: "dep"},
+				},
+				Edges: []*Edge{
+					{Type: Edge_dependsOn, From: "root", To: []string{"dep"}},
+				},
+				RootElements: []string{"root"},
+			},
+			types:     []Edge_Type{},
+			wantNodes: []string{"root", "dep"},
+			wantEdges: 1,
+		},
+		{
+			name: "edge removed but node kept when other edge remains",
+			sut: &NodeList{
+				Nodes: []*Node{
+					{Id: "root"}, {Id: "A"}, {Id: "B"},
+				},
+				Edges: []*Edge{
+					{Type: Edge_dependsOn, From: "root", To: []string{"A"}},
+					{Type: Edge_dependsOn, From: "A", To: []string{"B"}},
+					{Type: Edge_optionalDependency, From: "root", To: []string{"B"}},
+				},
+				RootElements: []string{"root"},
+			},
+			types:     []Edge_Type{Edge_optionalDependency},
+			wantNodes: []string{"root", "A", "B"},
+			wantEdges: 2,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.sut.RemoveNodesByEdgeType(tc.types...)
+
+			var gotNodeIDs []string
+			for _, n := range tc.sut.Nodes {
+				gotNodeIDs = append(gotNodeIDs, n.Id)
+			}
+
+			require.ElementsMatch(t, tc.wantNodes, gotNodeIDs)
+			require.Len(t, tc.sut.Edges, tc.wantEdges)
+		})
+	}
+}
+
 func TestAdd(t *testing.T) {
 	for _, tc := range []struct {
 		sut     *NodeList


### PR DESCRIPTION
This adds a new function to the nodelist: `RemoveNodesByEdgeType()`

This new function allow to remove entire classes of nodes depending on how they are connected to the graph. The utility here is that we can now remove all the test dependencies or build dependencies from an SBOM.

RemoveNodesByEdgeType removes all nodes connected by the specified edge type. When a node has more than one path, it remains but it loses the targeted edge.