### PR TITLE
Update SPDX media type strings

### DIFF
--- a/pkg/formats/formats.go
+++ b/pkg/formats/formats.go
@@ -13,10 +13,10 @@ const (
 	JSON       = "json"
 	XML        = "xml"
 	TEXT       = "text"
-	SPDX23TV   = Format("text/spdx+text;version=2.3")
-	SPDX23JSON = Format("text/spdx+json;version=2.3")
-	SPDX22TV   = Format("text/spdx+text;version=2.2")
-	SPDX22JSON = Format("text/spdx+json;version=2.2")
+	SPDX23TV   = Format("text/spdx;version=2.3")
+	SPDX23JSON = Format("application/spdx+json;version=2.3")
+	SPDX22TV   = Format("text/spdx;version=2.2")
+	SPDX22JSON = Format("application/spdx+json;version=2.2")
 	CDX10JSON  = Format("application/vnd.cyclonedx+json;version=1.0")
 	CDX11JSON  = Format("application/vnd.cyclonedx+json;version=1.1")
 	CDX12JSON  = Format("application/vnd.cyclonedx+json;version=1.2")

--- a/pkg/native/serializers/beta/serializer_spdx3.go
+++ b/pkg/native/serializers/beta/serializer_spdx3.go
@@ -21,7 +21,7 @@ type SPDX3Options struct {
 }
 
 func init() {
-	writer.RegisterSerializer(formats.Format("text/spdx+json;version=3.0"), &SPDX3{})
+	writer.RegisterSerializer(formats.Format("application/spdx+json;version=3.0"), &SPDX3{})
 }
 
 func NewSPDX3() *SPDX3 {

--- a/pkg/reader/reader_test.go
+++ b/pkg/reader/reader_test.go
@@ -496,7 +496,7 @@ func TestReaderSourceData(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	require.Equal(t, "text/spdx+json;version=2.3", doc.Metadata.SourceData.Format)
+	require.Equal(t, "application/spdx+json;version=2.3", doc.Metadata.SourceData.Format)
 	require.Len(t, doc.Metadata.SourceData.Hashes, 3)
 	require.Equal(t, int64(1472), doc.Metadata.SourceData.Size)
 	require.Equal(t, "2f48db1a89d5e7f8b2d4d1a412be14d932f5613f", doc.Metadata.SourceData.Hashes[int32(sbom.HashAlgorithm_SHA1)])


### PR DESCRIPTION
Use media type strings as registered with IANA (`application/spdx+json` and `text/spdx`):

- https://www.iana.org/assignments/media-types/application/spdx+json
- https://www.iana.org/assignments/media-types/text/spdx

`Encoding()` and `Type()` should still working as before, since they are rely on strings containing "text", "json", and "spdx", which the new strings are still contain.

To fix #409
