### PR TITLE
Add "headless" cyclonedx mod.  

### DIFF
--- a/pkg/mod/mod.go
+++ b/pkg/mod/mod.go
@@ -25,3 +25,22 @@ const SPDX_RENDER_PROPERTIES_IN_ANNOTATIONS = Mod("SPDX_RENDER_PROPERTIES")
 // annotations by "protobom - v1.0.0" into an sbom.Property and store it in the
 // node properties.
 const SPDX_READ_ANNOTATIONS_TO_PROPERTIES = Mod("SPDX_READ_ANNOTATIONS_TO_PROPERTIES")
+
+// CYCLONEDX_MULTIROOT_HEADLESS is a mod that controls how the CycloneDX
+// serializer handles documents with two or more root nodes.
+//
+// CycloneDX has a single optional metadata.component slot which protobom
+// normally uses for the document's single root. When the protobom NodeList has
+// multiple roots, the serializer would otherwise fail because the graph cannot
+// be represented faithfully.
+//
+// When this mod is enabled, the serializer instead "lowers" the graph by one
+// level: metadata.component is omitted entirely and the protobom root nodes
+// become the top-level entries of the CycloneDX components array (and the
+// first-level entries of the dependency graph). The resulting document is a
+// valid "headless" CycloneDX BOM.
+//
+// The unserializer always reads headless CycloneDX documents (those without
+// metadata.component) in this same spirit, treating the top-level components
+// as the protobom NodeList root nodes. This mod is not required on read.
+const CYCLONEDX_MULTIROOT_HEADLESS = Mod("CYCLONEDX_MULTIROOT_HEADLESS")

--- a/pkg/native/serializers/serializer_cdx.go
+++ b/pkg/native/serializers/serializer_cdx.go
@@ -15,6 +15,7 @@ import (
 	"github.com/google/uuid"
 
 	cdxformats "github.com/protobom/protobom/pkg/formats/cyclonedx"
+	"github.com/protobom/protobom/pkg/mod"
 	"github.com/protobom/protobom/pkg/native"
 	"github.com/protobom/protobom/pkg/sbom"
 )
@@ -64,7 +65,7 @@ func NewCDX(version, encoding string) *CDX {
 	}
 }
 
-func (s *CDX) Serialize(bom *sbom.Document, _ *native.SerializeOptions, rawopts interface{}) (interface{}, error) {
+func (s *CDX) Serialize(bom *sbom.Document, serializeopts *native.SerializeOptions, rawopts interface{}) (interface{}, error) {
 	// Load the context with the CDX value. We initialize a context here
 	// but we should get it as part of the method to capture cancelations
 	// from the CLI or REST API.
@@ -108,6 +109,9 @@ func (s *CDX) Serialize(bom *sbom.Document, _ *native.SerializeOptions, rawopts 
 	}
 	doc.Metadata = md
 
+	// Check if we have headless support on
+	headless := serializeopts != nil && serializeopts.IsModEnabled(mod.CYCLONEDX_MULTIROOT_HEADLESS)
+
 	// Check if the protobom has no root elements:
 	if len(bom.NodeList.RootElements) == 0 {
 		// Empty (nodeless) document
@@ -119,38 +123,62 @@ func (s *CDX) Serialize(bom *sbom.Document, _ *native.SerializeOptions, rawopts 
 		return nil, fmt.Errorf("unable to build cyclonedx document, no root nodes found")
 	}
 
-	// .. or has too many root elements:
-
-	// TODO(deprecation): If there are more root nodes we need to hack them
-	// into the CycloneDX graph or error
-	if l := len(bom.NodeList.RootElements); l > 1 {
-		return nil, fmt.Errorf("unable to serialize multiroot cyclonedx, document has %d root nodes", l)
+	// Reject documents with more than one root unless the caller opted into
+	// the headless mod, which promotes all roots to top-level components.
+	if l := len(bom.NodeList.RootElements); l > 1 && !headless {
+		return nil, fmt.Errorf("unable to serialize multiroot (%d) cyclonedx, (mod.CYCLONEDX_MULTIROOT_HEADLESS disabled)", l)
 	}
 
-	// Convert all nodes to cdx cmponents
+	// Convert all nodes to cdx components
 	components := map[string]*cdx.Component{}
 	for _, node := range bom.NodeList.Nodes {
 		components[node.Id] = s.nodeToComponent(node)
 	}
 
-	// CLear the protobom generated bomrefs
+	// Clear the protobom generated bomrefs
 	clearAutoRefs(components)
 
-	rootNode := bom.NodeList.GetNodeByID(bom.NodeList.RootElements[0])
-	if rootNode == nil {
-		return nil, fmt.Errorf("integrity error: root node %q not found", bom.NodeList.RootElements[0])
-	}
+	if headless && len(bom.NodeList.RootElements) > 1 {
+		// Drop metadata.component entirely and promote each protobom root to
+		// a top-level CycloneDX component, attaching its contained subtree.
+		doc.Metadata.Component = nil
 
-	doc.Metadata.Component = s.nodeToComponent(rootNode)
+		seen := map[string]struct{}{}
+		for _, rootID := range bom.NodeList.RootElements {
+			seen[rootID] = struct{}{}
+		}
 
-	// Extract the component tree
-	componentTree, err := recurseComponentComponents(
-		rootNode.Id, bom.NodeList, components, &map[string]struct{}{rootNode.Id: {}},
-	)
-	if err != nil {
-		return nil, fmt.Errorf("building component tree: %w", err)
+		topComponents := []cdx.Component{}
+		for _, rootID := range bom.NodeList.RootElements {
+			rootComp, ok := components[rootID]
+			if !ok {
+				return nil, fmt.Errorf("integrity error: root component %q not found", rootID)
+			}
+			subtree, err := recurseComponentComponents(rootID, bom.NodeList, components, &seen)
+			if err != nil {
+				return nil, fmt.Errorf("building component tree for root %q: %w", rootID, err)
+			}
+			rootComp.Components = subtree
+			topComponents = append(topComponents, *rootComp)
+		}
+		doc.Components = &topComponents
+	} else {
+		rootNode := bom.NodeList.GetNodeByID(bom.NodeList.RootElements[0])
+		if rootNode == nil {
+			return nil, fmt.Errorf("integrity error: root node %q not found", bom.NodeList.RootElements[0])
+		}
+
+		doc.Metadata.Component = s.nodeToComponent(rootNode)
+
+		// Extract the component tree
+		componentTree, err := recurseComponentComponents(
+			rootNode.Id, bom.NodeList, components, &map[string]struct{}{rootNode.Id: {}},
+		)
+		if err != nil {
+			return nil, fmt.Errorf("building component tree: %w", err)
+		}
+		doc.Components = componentTree
 	}
-	doc.Components = componentTree
 
 	// Build the dependency graph:
 	deps, err := buildDependencies(bom.NodeList, components)
@@ -159,7 +187,7 @@ func (s *CDX) Serialize(bom *sbom.Document, _ *native.SerializeOptions, rawopts 
 	}
 	doc.Dependencies = &deps
 
-	if bom.Metadata != nil && bom.GetMetadata().GetName() != "" {
+	if !headless && bom.Metadata != nil && bom.GetMetadata().GetName() != "" {
 		doc.Metadata.Component.Name = bom.GetMetadata().GetName()
 	}
 

--- a/pkg/native/unserializers/unserializer_cdx.go
+++ b/pkg/native/unserializers/unserializer_cdx.go
@@ -95,7 +95,10 @@ func (u *CDX) Unserialize(r io.Reader, _ *native.UnserializeOptions, _ interface
 		}
 	}
 
-	// Cycle all components and get their graph fragments
+	// Cycle all components and get their graph fragments. A CycloneDX BOM
+	// without a metadata.component is treated as "headless": each top-level
+	// component becomes a protobom root node. This matches the inverse of
+	// the mod.CYCLONEDX_MULTIROOT_HEADLESS write path.
 	hasRootComponent := bom.Metadata != nil && bom.Metadata.Component != nil
 	if bom.Components != nil {
 		for i := range *bom.Components {
@@ -103,9 +106,6 @@ func (u *CDX) Unserialize(r io.Reader, _ *native.UnserializeOptions, _ interface
 			if err != nil {
 				return nil, fmt.Errorf("converting component to node: %w", err)
 			}
-
-			// TODO(mod): Write a hack to force one componento to the top
-			// if there is no component in the metadata.
 
 			// If the CDX doc does not have a top level component,
 			// then the nodes come in as top level nodes:

--- a/test/conformance/roundtrip_headless_test.go
+++ b/test/conformance/roundtrip_headless_test.go
@@ -1,0 +1,199 @@
+// SPDX-FileCopyrightText: Copyright 2026 The Protobom Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package conformance
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	cdx "github.com/CycloneDX/cyclonedx-go"
+	"github.com/stretchr/testify/require"
+
+	"github.com/protobom/protobom/pkg/formats"
+	"github.com/protobom/protobom/pkg/mod"
+	"github.com/protobom/protobom/pkg/native"
+	"github.com/protobom/protobom/pkg/reader"
+	"github.com/protobom/protobom/pkg/sbom"
+	"github.com/protobom/protobom/pkg/writer"
+)
+
+// newMultirootDoc returns a synthetic protobom document with two top-level
+// roots wired by a cross-root dependsOn edge. This is the minimal shape that
+// exercises the headless write path (multiple roots + a dependency graph) and
+// the symmetric read path.
+func newMultirootDoc() *sbom.Document {
+	return &sbom.Document{
+		Metadata: &sbom.Metadata{
+			Id:      "urn:uuid:11111111-2222-3333-4444-555555555555",
+			Version: "1",
+		},
+		NodeList: &sbom.NodeList{
+			RootElements: []string{"root-a", "root-b"},
+			Nodes: []*sbom.Node{
+				{
+					Id:                 "root-a",
+					Type:               sbom.Node_PACKAGE,
+					Name:               "root-a",
+					Version:            "1.0.0",
+					PrimaryPurpose:     []sbom.Purpose{sbom.Purpose_APPLICATION},
+					Licenses:           []string{},
+					Attribution:        []string{},
+					Suppliers:          []*sbom.Person{},
+					Originators:        []*sbom.Person{},
+					ExternalReferences: []*sbom.ExternalReference{},
+					FileTypes:          []string{},
+					Identifiers:        map[int32]string{},
+					Hashes:             map[int32]string{},
+				},
+				{
+					Id:                 "root-b",
+					Type:               sbom.Node_PACKAGE,
+					Name:               "root-b",
+					Version:            "2.0.0",
+					PrimaryPurpose:     []sbom.Purpose{sbom.Purpose_APPLICATION},
+					Licenses:           []string{},
+					Attribution:        []string{},
+					Suppliers:          []*sbom.Person{},
+					Originators:        []*sbom.Person{},
+					ExternalReferences: []*sbom.ExternalReference{},
+					FileTypes:          []string{},
+					Identifiers:        map[int32]string{},
+					Hashes:             map[int32]string{},
+				},
+			},
+			Edges: []*sbom.Edge{
+				{From: "root-a", Type: sbom.Edge_dependsOn, To: []string{"root-b"}},
+			},
+		},
+	}
+}
+
+func headlessOptions(format formats.Format) *writer.Options {
+	return &writer.Options{
+		Format: format,
+		RenderOptions: &native.RenderOptions{
+			Indent: 2,
+		},
+		SerializeOptions: &native.SerializeOptions{
+			Mods: map[mod.Mod]struct{}{
+				mod.CYCLONEDX_MULTIROOT_HEADLESS: {},
+			},
+		},
+	}
+}
+
+// TestCycloneDXHeadlessRoundtrip exercises the mod.CYCLONEDX_MULTIROOT_HEADLESS
+// write path and the symmetric headless read path: a multiroot protobom
+// document is serialized to a "headless" CycloneDX BOM (no metadata.component)
+// and parsed back, then the result is compared to the original via
+// NodeList.Equal.
+//
+// CycloneDX 1.7 is omitted because the cyclonedx-go library cannot decode
+// it (the protobom serializer patches the specVersion on output, but the
+// decoder still rejects 1.7 on read).
+func TestCycloneDXHeadlessRoundtrip(t *testing.T) {
+	for _, format := range []formats.Format{
+		formats.CDX14JSON,
+		formats.CDX15JSON,
+		formats.CDX16JSON,
+	} {
+		t.Run(string(format), func(t *testing.T) {
+			original := newMultirootDoc()
+
+			w := writer.New()
+			var buf bytes.Buffer
+			require.NoError(t, w.WriteStreamWithOptions(original, &buf, headlessOptions(format)))
+
+			// The rendered document must be genuinely headless: parse it
+			// directly via cyclonedx-go and assert metadata.component is nil
+			// and both roots are present as top-level components.
+			rendered := buf.Bytes()
+			decoded := &cdx.BOM{}
+			require.NoError(t,
+				cdx.NewBOMDecoder(bytes.NewReader(rendered), cdx.BOMFileFormatJSON).Decode(decoded),
+			)
+			require.NotNil(t, decoded.Metadata)
+			require.Nil(t, decoded.Metadata.Component, "headless BOM must not carry metadata.component")
+			require.NotNil(t, decoded.Components)
+			require.Len(t, *decoded.Components, 2, "both roots should be top-level components")
+
+			topRefs := map[string]bool{}
+			for _, c := range *decoded.Components {
+				topRefs[c.BOMRef] = true
+			}
+			require.True(t, topRefs["root-a"], "root-a should be a top-level component")
+			require.True(t, topRefs["root-b"], "root-b should be a top-level component")
+
+			// Now go through protobom's reader and verify equivalence.
+			roundtripped, err := reader.New().ParseStream(bytes.NewReader(rendered))
+			require.NoError(t, err)
+
+			require.True(t,
+				original.NodeList.Equal(roundtripped.NodeList),
+				"roundtripped nodelist must equal original\noriginal: %+v\nroundtripped: %+v",
+				original.NodeList, roundtripped.NodeList,
+			)
+		})
+	}
+}
+
+// TestCycloneDXHeadlessReadWithoutMod confirms the unserializer side: a CDX
+// document that lacks metadata.component is always read as headless, with
+// each top-level component surfaced as a protobom root. The reader does not
+// require any mod to do this.
+func TestCycloneDXHeadlessReadWithoutMod(t *testing.T) {
+	const headlessJSON = `{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5",
+  "serialNumber": "urn:uuid:11111111-2222-3333-4444-555555555555",
+  "version": 1,
+  "components": [
+    {
+      "bom-ref": "root-a",
+      "type": "application",
+      "name": "root-a",
+      "version": "1.0.0"
+    },
+    {
+      "bom-ref": "root-b",
+      "type": "application",
+      "name": "root-b",
+      "version": "2.0.0"
+    }
+  ],
+  "dependencies": [
+    {"ref": "root-a", "dependsOn": ["root-b"]}
+  ]
+}`
+
+	doc, err := reader.New().ParseStream(strings.NewReader(headlessJSON))
+	require.NoError(t, err)
+
+	require.ElementsMatch(t, []string{"root-a", "root-b"}, doc.NodeList.RootElements)
+	require.Len(t, doc.NodeList.Nodes, 2)
+	require.Len(t, doc.NodeList.Edges, 1)
+	require.Equal(t, "root-a", doc.NodeList.Edges[0].From)
+	require.Equal(t, sbom.Edge_dependsOn, doc.NodeList.Edges[0].Type)
+	require.Equal(t, []string{"root-b"}, doc.NodeList.Edges[0].To)
+}
+
+// TestCycloneDXMultirootRejectedWithoutMod confirms the pre-existing safety
+// net: a multiroot document still fails to serialize when the headless mod
+// is not opted in.
+func TestCycloneDXMultirootRejectedWithoutMod(t *testing.T) {
+	original := newMultirootDoc()
+	w := writer.New()
+
+	opts := &writer.Options{
+		Format:           formats.CDX15JSON,
+		RenderOptions:    &native.RenderOptions{Indent: 2},
+		SerializeOptions: &native.SerializeOptions{},
+	}
+
+	var buf bytes.Buffer
+	err := w.WriteStreamWithOptions(original, &buf, opts)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "multiroot")
+}


### PR DESCRIPTION
This pr implements the planned "headless" cyclonedx hack, one of the proposed multiroot solutions where protobom will serialize a cdx document without the top level component when more than one root node is found on the graph.

Signed-off-by: Adolfo Garcia Veytia (puerco) <puerco@carabiner.dev>