### PR TITLE
fix(cdx): surface metadata.tools in the CycloneDX unserializer

### DIFF
--- a/pkg/native/unserializers/unserializer_cdx.go
+++ b/pkg/native/unserializers/unserializer_cdx.go
@@ -93,6 +93,7 @@ func (u *CDX) Unserialize(r io.Reader, _ *native.UnserializeOptions, _ interface
 				md.Date = timestamppb.New(t)
 			}
 		}
+		md.Tools = append(md.Tools, u.metadataToolsToTools(bom.Metadata.Tools)...)
 	}
 
 	// Cycle all components and get their graph fragments. A CycloneDX BOM
@@ -129,6 +130,92 @@ func (u *CDX) Unserialize(r io.Reader, _ *native.UnserializeOptions, _ interface
 	doc.NodeList.MergeEdges(deps)
 
 	return doc, nil
+}
+
+// metadataToolsToTools converts the tools recorded in a CycloneDX
+// metadata.tools field into protobom Tool entries. CycloneDX exposes two
+// shapes here and both are live in the wild: the legacy array of Tool objects
+// (CDX 1.4 and still emitted by some generators under 1.6) and the 1.5+ object
+// form that nests tools as components and services. This reads whichever shape
+// the document uses so the data survives the round trip; previously it was
+// silently dropped. This mirrors how the SPDX unserializer surfaces the Tool
+// creators it finds in CreationInfo.
+func (u *CDX) metadataToolsToTools(tc *cdx.ToolsChoice) []*sbom.Tool {
+	tools := []*sbom.Tool{}
+	if tc == nil {
+		return tools
+	}
+
+	// Legacy array form: metadata.tools: [ { vendor, name, version }, ... ]
+	if tc.Tools != nil {
+		for _, t := range *tc.Tools { //nolint:staticcheck // Tools is deprecated in CDX but still read for older documents
+			if t.Name == "" && t.Vendor == "" && t.Version == "" {
+				continue
+			}
+			tools = append(tools, &sbom.Tool{
+				Name:    t.Name,
+				Version: t.Version,
+				Vendor:  t.Vendor,
+			})
+		}
+	}
+
+	// CDX 1.5+ object form: metadata.tools.components are the generators. There
+	// is no single vendor field on a component, so fall back through the fields
+	// real generators populate: publisher, then manufacturer.name, then the
+	// (deprecated) author string, then group.
+	if tc.Components != nil {
+		for _, c := range *tc.Components {
+			if c.Name == "" {
+				continue
+			}
+			tools = append(tools, &sbom.Tool{
+				Name:    c.Name,
+				Version: c.Version,
+				Vendor:  componentVendor(&c),
+			})
+		}
+	}
+
+	// Services may also appear under the 1.5+ object form (for example a hosted
+	// scanner). Provider.Name or group is the closest analog to a vendor.
+	if tc.Services != nil {
+		for _, s := range *tc.Services {
+			if s.Name == "" {
+				continue
+			}
+			vendor := s.Group
+			if s.Provider != nil && s.Provider.Name != "" {
+				vendor = s.Provider.Name
+			}
+			tools = append(tools, &sbom.Tool{
+				Name:    s.Name,
+				Version: s.Version,
+				Vendor:  vendor,
+			})
+		}
+	}
+
+	return tools
+}
+
+// componentVendor picks the best available "vendor" for a tool recorded as a
+// CycloneDX component, since a component has no dedicated vendor field.
+func componentVendor(c *cdx.Component) string {
+	switch {
+	case c.Publisher != "":
+		return c.Publisher
+	case c.Manufacturer != nil && c.Manufacturer.Name != "":
+		return c.Manufacturer.Name
+	case c.Author != "": //nolint:staticcheck // Author is deprecated in CDX but still emitted by some generators
+		return c.Author
+	case c.Group != "":
+		return c.Group
+	case c.Supplier != nil && c.Supplier.Name != "":
+		return c.Supplier.Name
+	default:
+		return ""
+	}
 }
 
 // componentToNodes takes a CycloneDX component and computes its graph fragment,

--- a/pkg/native/unserializers/unserializer_cdx_test.go
+++ b/pkg/native/unserializers/unserializer_cdx_test.go
@@ -1,6 +1,7 @@
 package unserializers
 
 import (
+	"strings"
 	"testing"
 
 	cdx "github.com/CycloneDX/cyclonedx-go"
@@ -120,6 +121,158 @@ func TestCdxExtRefTypeToProtobomType(t *testing.T) {
 	} {
 		res := cdxu.cdxExtRefTypeToProtobomType(cdxRefType)
 		require.Equal(t, protoType, res)
+	}
+}
+
+func TestMetadataToolsToTools(t *testing.T) {
+	cdxu := NewCDX(cdxUnserializerTestVersion, cdxUnserializerTestEncoding)
+	for _, tc := range []struct {
+		name     string
+		sut      *cdx.ToolsChoice
+		expected []*sbom.Tool
+	}{
+		{
+			name:     "nil choice",
+			sut:      nil,
+			expected: []*sbom.Tool{},
+		},
+		{
+			name: "legacy tools array",
+			sut: &cdx.ToolsChoice{
+				Tools: &[]cdx.Tool{ //nolint:staticcheck
+					{Vendor: "anchore", Name: "syft", Version: "0.100.0"},
+					{Name: "cyclonedx-gomod", Version: "1.4.0"},
+				},
+			},
+			expected: []*sbom.Tool{
+				{Name: "syft", Version: "0.100.0", Vendor: "anchore"},
+				{Name: "cyclonedx-gomod", Version: "1.4.0"},
+			},
+		},
+		{
+			name: "legacy empty tool skipped",
+			sut: &cdx.ToolsChoice{
+				Tools: &[]cdx.Tool{{}}, //nolint:staticcheck
+			},
+			expected: []*sbom.Tool{},
+		},
+		{
+			name: "components form with publisher",
+			sut: &cdx.ToolsChoice{
+				Components: &[]cdx.Component{
+					{Type: cdx.ComponentTypeApplication, Publisher: "anchore", Name: "syft", Version: "1.0.0"},
+				},
+			},
+			expected: []*sbom.Tool{
+				{Name: "syft", Version: "1.0.0", Vendor: "anchore"},
+			},
+		},
+		{
+			name: "components form vendor fallbacks",
+			sut: &cdx.ToolsChoice{
+				Components: &[]cdx.Component{
+					{Name: "tool-manufacturer", Version: "1", Manufacturer: &cdx.OrganizationalEntity{Name: "trivy-org"}},
+					{Name: "tool-author", Version: "2", Author: "syft-author"}, //nolint:staticcheck
+					{Name: "tool-group", Version: "3", Group: "aquasecurity"},
+					{Name: "tool-noname-skipped-when-empty", Version: "4"},
+				},
+			},
+			expected: []*sbom.Tool{
+				{Name: "tool-manufacturer", Version: "1", Vendor: "trivy-org"},
+				{Name: "tool-author", Version: "2", Vendor: "syft-author"},
+				{Name: "tool-group", Version: "3", Vendor: "aquasecurity"},
+				{Name: "tool-noname-skipped-when-empty", Version: "4"},
+			},
+		},
+		{
+			name: "component without a name is skipped",
+			sut: &cdx.ToolsChoice{
+				Components: &[]cdx.Component{{Type: cdx.ComponentTypeApplication, Publisher: "anchore"}},
+			},
+			expected: []*sbom.Tool{},
+		},
+		{
+			name: "services form",
+			sut: &cdx.ToolsChoice{
+				Services: &[]cdx.Service{
+					{Name: "hosted-scanner", Version: "9", Provider: &cdx.OrganizationalEntity{Name: "vendor-inc"}},
+				},
+			},
+			expected: []*sbom.Tool{
+				{Name: "hosted-scanner", Version: "9", Vendor: "vendor-inc"},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := cdxu.metadataToolsToTools(tc.sut)
+			require.Len(t, got, len(tc.expected))
+			for i := range tc.expected {
+				require.Equal(t, tc.expected[i].Name, got[i].Name)
+				require.Equal(t, tc.expected[i].Version, got[i].Version)
+				require.Equal(t, tc.expected[i].Vendor, got[i].Vendor)
+			}
+		})
+	}
+}
+
+// TestUnserializeMetadataTools is the end-to-end regression guard for
+// protobom/protobom#417: a parsed CycloneDX document must surface its
+// metadata.tools entries in Document.Metadata.Tools for both the legacy array
+// shape and the 1.5+ components object shape.
+func TestUnserializeMetadataTools(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		version string
+		doc     string
+		want    []*sbom.Tool
+	}{
+		{
+			name:    "legacy tools array",
+			version: "1.4",
+			doc: `{
+			  "bomFormat": "CycloneDX",
+			  "specVersion": "1.4",
+			  "version": 1,
+			  "metadata": {
+			    "tools": [
+			      { "vendor": "anchore", "name": "syft", "version": "0.100.0" }
+			    ]
+			  },
+			  "components": []
+			}`,
+			want: []*sbom.Tool{{Name: "syft", Version: "0.100.0", Vendor: "anchore"}},
+		},
+		{
+			name:    "components object form",
+			version: "1.5",
+			doc: `{
+			  "bomFormat": "CycloneDX",
+			  "specVersion": "1.5",
+			  "version": 1,
+			  "metadata": {
+			    "tools": {
+			      "components": [
+			        { "type": "application", "publisher": "anchore", "name": "syft", "version": "1.0.0" }
+			      ]
+			    }
+			  },
+			  "components": []
+			}`,
+			want: []*sbom.Tool{{Name: "syft", Version: "1.0.0", Vendor: "anchore"}},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			u := NewCDX(tc.version, cdxUnserializerTestEncoding)
+			doc, err := u.Unserialize(strings.NewReader(tc.doc), nil, nil)
+			require.NoError(t, err)
+			got := doc.GetMetadata().GetTools()
+			require.Len(t, got, len(tc.want), "metadata.tools should be surfaced, not dropped")
+			for i := range tc.want {
+				require.Equal(t, tc.want[i].Name, got[i].Name)
+				require.Equal(t, tc.want[i].Version, got[i].Version)
+				require.Equal(t, tc.want[i].Vendor, got[i].Vendor)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## What this fixes

Fixes #417.

The CycloneDX unserializer was dropping `metadata.tools`. After parsing any CDX SBOM, `Document.Metadata.Tools` was always empty, even when the source document had a populated tool list. The metadata struct is initialized with `Tools: []*sbom.Tool{}` and nothing downstream ever read `bom.Metadata.Tools`, so the data was silently lost on read.

This also closes a format asymmetry. The SPDX unserializer already surfaces its `Tool` creators from `CreationInfo`, so a consumer that wants to know which tool generated an SBOM gets it for SPDX but not for CycloneDX. With this change CDX behaves the same way.

## Root cause

In `pkg/native/unserializers/unserializer_cdx.go`, the `if bom.Metadata != nil` block handled lifecycles, the root component, and the timestamp, but never touched `bom.Metadata.Tools`. The field was initialized empty and left empty.

## Reproduction (before the fix)

```go
r := reader.New()
d, _ := r.ParseStream(f) // a CycloneDX JSON with metadata.tools populated
fmt.Println(len(d.GetMetadata().GetTools())) // prints 0 regardless of input
```

Confirmed against both shapes the spec allows, using a minimal CDX document for each:

- CDX 1.4 legacy array: `metadata.tools: [ { vendor, name, version }, ... ]` parsed to 0 tools.
- CDX 1.5+ object form: `metadata.tools: { components: [...] }` parsed to 0 tools.

## The fix

A new `metadataToolsToTools` helper maps `bom.Metadata.Tools` (a `cdx.ToolsChoice`) into protobom `Tool` entries, and it is now called in the metadata block. It handles every shape `ToolsChoice` can carry:

- The legacy `Tools` array (`[]cdx.Tool`), which is still emitted by generators like `cyclonedx-gomod` even under spec 1.6, so it stays relevant on read.
- The 1.5+ `Components` form. A tool component has no single vendor field, so the vendor is resolved through a fallback chain that matches what real generators populate: `publisher`, then `manufacturer.name`, then the deprecated `author` string, then `group`, then `supplier.name`.
- The 1.5+ `Services` form, using `provider.name` (or `group`) as the vendor analog.

Entries without a usable name are skipped. Nothing on the serialization path or any other field is touched.

## After the fix

Both shapes now surface `Name`, `Version`, and `Vendor`:

- Legacy array `{ "vendor": "anchore", "name": "syft", "version": "0.100.0" }` -> one `Tool{Name: "syft", Version: "0.100.0", Vendor: "anchore"}`.
- Components form `{ "publisher": "anchore", "name": "syft", "version": "1.0.0" }` -> one `Tool{Name: "syft", Version: "1.0.0", Vendor: "anchore"}`.

## Tests

- `TestMetadataToolsToTools` is a table test over the helper: nil choice, legacy array (including an all-empty entry that is skipped), the components form with `publisher`, the components vendor fallbacks (`manufacturer.name`, `author`, `group`), a nameless component that is skipped, and the services form.
- `TestUnserializeMetadataTools` is an end-to-end regression guard that runs the full `Unserialize` path on a real CDX JSON for both the legacy array and the components object form and asserts the tools are surfaced.

I verified the end-to-end test fails (0 tools, the exact bug symptom) when the new call is removed and passes with it in place. `go build ./...`, `go test ./pkg/native/... ./test/...` (including the conformance suite), `go vet`, and `gofmt`/`gofumpt` are all clean.

## Notes

- No proto change is needed; `sbom.Tool` already has `Name`, `Version`, and `Vendor`.
- This is read-only behavior for the unserializer. The existing serializer write path (`ToolsChoice.Tools`) is unchanged.
