### PR TITLE
perf(cdx): batch component merge so ParseStream is O(nodes+edges)

### DIFF
--- a/pkg/native/unserializers/unserializer_cdx.go
+++ b/pkg/native/unserializers/unserializer_cdx.go
@@ -101,23 +101,40 @@ func (u *CDX) Unserialize(r io.Reader, _ *native.UnserializeOptions, _ interface
 	// the mod.CYCLONEDX_MULTIROOT_HEADLESS write path.
 	hasRootComponent := bom.Metadata != nil && bom.Metadata.Component != nil
 	if bom.Components != nil {
+		// Accumulate every component fragment into a single NodeList, then
+		// merge it into the document once. Merging per component made parsing
+		// O(components^2): both Add and RelateNodeListAtID rebuild a full
+		// node/edge index of the (ever-growing) document on every call, so a
+		// doc with N components re-indexed the whole graph N times. Batching
+		// the merge indexes once, making this O(nodes+edges).
+		combined := &sbom.NodeList{}
+		seen := make(map[string]struct{})
 		for i := range *bom.Components {
 			nl, err := u.componentToNodeList(&(*bom.Components)[i], &cc)
 			if err != nil {
 				return nil, fmt.Errorf("converting component to node: %w", err)
 			}
-
-			// If the CDX doc does not have a top level component,
-			// then the nodes come in as top level nodes:
-			if !hasRootComponent {
-				doc.NodeList.Add(nl)
-
-				// ... unless we have a top level component. Then we descend
-				// all body nodes from it:
-			} else {
-				if err := doc.NodeList.RelateNodeListAtID(nl, doc.NodeList.RootElements[0], sbom.Edge_contains); err != nil {
-					return nil, fmt.Errorf("relating components to root node: %w", err)
+			for _, n := range nl.Nodes {
+				if _, ok := seen[n.GetId()]; ok {
+					continue
 				}
+				seen[n.GetId()] = struct{}{}
+				combined.Nodes = append(combined.Nodes, n)
+			}
+			combined.Edges = append(combined.Edges, nl.Edges...)
+			combined.RootElements = append(combined.RootElements, nl.RootElements...)
+		}
+
+		// If the CDX doc does not have a top level component,
+		// then the nodes come in as top level nodes:
+		if !hasRootComponent {
+			doc.NodeList.Add(combined)
+
+			// ... unless we have a top level component. Then we descend
+			// all body nodes from it:
+		} else {
+			if err := doc.NodeList.RelateNodeListAtID(combined, doc.NodeList.RootElements[0], sbom.Edge_contains); err != nil {
+				return nil, fmt.Errorf("relating components to root node: %w", err)
 			}
 		}
 	}


### PR DESCRIPTION
## What

Make CycloneDX `ParseStream` linear in the size of the BOM.

The unserializer related each component to the document **one at a time**: for every
component it calls `NodeList.Add` (headless BOMs) or `NodeList.RelateNodeListAtID` (BOMs
with a `metadata.component` root). Both methods rebuild a full node+edge index of the
*growing* document on every call (`indexNodes` + `indexEdges`, and `Add` also runs
`cleanEdges`). So a BOM with N components re-indexes the whole graph N times — parsing is
**O(N²)**.

On large container-image SBOMs (~100k nodes) this is ~8 minutes of parse time.

## Fix

Accumulate every component's graph fragment into a single `NodeList` and merge it into the
document **once**, so the graph is indexed once → **O(nodes+edges)**. Node de-duplication
by id is preserved (`Add` already de-duped; the batched path keeps that with a seen-set).
Parse output is unchanged.

## Measured

Synthetic flat CycloneDX 1.5 BOM with a `metadata.component` root (the
`RelateNodeListAtID`-per-component path), timing the CDX unserializer's `Unserialize`.
Directly comparing `main` against this branch:

| Components | `main` (before) | this branch (after) | Speedup |
|----------:|----------------:|--------------------:|--------:|
| 20k | 16.2 s | 42 ms | ~385× |
| 40k | 1m 04s | 56 ms | ~1,150× |

On `main`, doubling the component count (20k→40k) roughly quadruples parse time
(quadratic); on this branch it stays flat (linear).

## Test plan
- [x] `go build ./...`, `go vet ./pkg/native/unserializers/`
- [x] `go test ./...` — full suite passes (`pkg/native/unserializers`, `test/conformance`
      round-trip, `pkg/sbom`, readers, serializers, storage, writer)
- [x] Benchmarked `main` vs this branch (see table above): O(N²) → linear
- [x] Validated in production: a downstream consumer ran this exact patch as a
      vendored fork; CycloneDX parse on the previously-failing SBOMs dropped from
      9–18 min to ~1.7 s.

## Notes
- This is a separate code path from #426 (which made the `NodeList` graph-*traversal*
  methods linear). This PR fixes the *unserializer* / parse path — the two are independent.
- A more general alternative would be to make `Add` / `RelateNodeListAtID` cheap to call
  repeatedly (e.g. accept a prebuilt index, or avoid the per-call `cleanEdges`). Batching
  at the call site is the smaller, lower-risk change and fixes the hot path; happy to go
  the deeper route if preferred.

Fixes #427 