### PR TITLE
fix(cdx): populate metadata.tools in the CycloneDX unserializer

### DIFF
--- a/pkg/native/unserializers/unserializer_cdx.go
+++ b/pkg/native/unserializers/unserializer_cdx.go
@@ -93,6 +93,7 @@ func (u *CDX) Unserialize(r io.Reader, _ *native.UnserializeOptions, _ interface
 				md.Date = timestamppb.New(t)
 			}
 		}
+		md.Tools = u.cdxToolsToSBOMTools(bom.Metadata.Tools)
 	}
 
 	// Cycle all components and get their graph fragments. A CycloneDX BOM
@@ -146,6 +147,82 @@ func (u *CDX) Unserialize(r io.Reader, _ *native.UnserializeOptions, _ interface
 	doc.NodeList.MergeEdges(deps)
 
 	return doc, nil
+}
+
+// cdxToolsToSBOMTools reads the metadata.tools of a CycloneDX document and
+// returns the protobom tools it describes. CycloneDX allows two shapes here:
+// the legacy 1.4 array of Tool objects (vendor/name/version), and the 1.5+
+// object form that carries tools as Components and Services. Both are still
+// emitted in the wild (for example cyclonedx-gomod keeps writing the legacy
+// array), so we surface whichever the document happens to use. Everything is
+// nil-guarded so a document with no tools just yields an empty slice.
+func (u *CDX) cdxToolsToSBOMTools(tc *cdx.ToolsChoice) []*sbom.Tool {
+	tools := []*sbom.Tool{}
+	if tc == nil {
+		return tools
+	}
+
+	// Legacy 1.4 array form: vendor/name/version map straight across.
+	if tc.Tools != nil {
+		for _, t := range *tc.Tools {
+			tools = append(tools, &sbom.Tool{
+				Name:    t.Name,
+				Version: t.Version,
+				Vendor:  t.Vendor,
+			})
+		}
+	}
+
+	// 1.5+ object form: tool components. There is no single vendor field on a
+	// component, so derive one from the first populated of publisher,
+	// manufacturer name, author, or group. Different generators fill different
+	// fields (mikebom uses publisher, trivy manufacturer.name, syft author).
+	if tc.Components != nil {
+		for _, c := range *tc.Components {
+			tools = append(tools, &sbom.Tool{
+				Name:    c.Name,
+				Version: c.Version,
+				Vendor:  componentVendor(&c),
+			})
+		}
+	}
+
+	// 1.5+ object form: services. A service has no vendor either, so fall back
+	// to its provider name and then its group.
+	if tc.Services != nil {
+		for _, s := range *tc.Services {
+			vendor := ""
+			if s.Provider != nil {
+				vendor = s.Provider.Name
+			}
+			if vendor == "" {
+				vendor = s.Group
+			}
+			tools = append(tools, &sbom.Tool{
+				Name:    s.Name,
+				Version: s.Version,
+				Vendor:  vendor,
+			})
+		}
+	}
+
+	return tools
+}
+
+// componentVendor picks a best-effort vendor for a CycloneDX tool component.
+// A component has no dedicated vendor field, so we take the first non-empty of
+// publisher, manufacturer name, author, or group.
+func componentVendor(c *cdx.Component) string {
+	if c.Publisher != "" {
+		return c.Publisher
+	}
+	if c.Manufacturer != nil && c.Manufacturer.Name != "" {
+		return c.Manufacturer.Name
+	}
+	if c.Author != "" {
+		return c.Author
+	}
+	return c.Group
 }
 
 // componentToNodes takes a CycloneDX component and computes its graph fragment,

--- a/pkg/native/unserializers/unserializer_cdx_test.go
+++ b/pkg/native/unserializers/unserializer_cdx_test.go
@@ -1,6 +1,7 @@
 package unserializers
 
 import (
+	"strings"
 	"testing"
 
 	cdx "github.com/CycloneDX/cyclonedx-go"
@@ -173,6 +174,140 @@ func TestDeterministicIds(t *testing.T) {
 				names = append(names, nodelist.Nodes[i].Id)
 			}
 			require.Equal(t, tc.expected, names)
+		})
+	}
+}
+
+func TestCdxToolsToSBOMTools(t *testing.T) {
+	cdxu := NewCDX(cdxUnserializerTestVersion, cdxUnserializerTestEncoding)
+	for _, tc := range []struct {
+		name     string
+		sut      *cdx.ToolsChoice
+		expected []*sbom.Tool
+	}{
+		{
+			name:     "nil choice",
+			sut:      nil,
+			expected: []*sbom.Tool{},
+		},
+		{
+			name: "legacy 1.4 array",
+			sut: &cdx.ToolsChoice{
+				Tools: &[]cdx.Tool{
+					{Vendor: "CycloneDX", Name: "cyclonedx-gomod", Version: "v1.4.0"},
+					{Name: "syft"},
+				},
+			},
+			expected: []*sbom.Tool{
+				{Name: "cyclonedx-gomod", Version: "v1.4.0", Vendor: "CycloneDX"},
+				{Name: "syft"},
+			},
+		},
+		{
+			name: "1.5 components with vendor fallbacks",
+			sut: &cdx.ToolsChoice{
+				Components: &[]cdx.Component{
+					// publisher wins
+					{Name: "mikebom", Version: "1.0.0", Publisher: "Mike", Author: "ignored"},
+					// manufacturer.name is next when publisher is empty
+					{Name: "trivy", Version: "0.50.0", Manufacturer: &cdx.OrganizationalEntity{Name: "Aqua Security"}},
+					// author is next
+					{Name: "syft", Version: "1.0.0", Author: "anchore"},
+					// group is the last resort
+					{Name: "tool-x", Version: "2.0.0", Group: "acme"},
+					// nothing populated leaves vendor empty
+					{Name: "bare", Version: "3.0.0"},
+				},
+			},
+			expected: []*sbom.Tool{
+				{Name: "mikebom", Version: "1.0.0", Vendor: "Mike"},
+				{Name: "trivy", Version: "0.50.0", Vendor: "Aqua Security"},
+				{Name: "syft", Version: "1.0.0", Vendor: "anchore"},
+				{Name: "tool-x", Version: "2.0.0", Vendor: "acme"},
+				{Name: "bare", Version: "3.0.0"},
+			},
+		},
+		{
+			name: "1.5 services",
+			sut: &cdx.ToolsChoice{
+				Services: &[]cdx.Service{
+					{Name: "scan-svc", Version: "1.2.3", Provider: &cdx.OrganizationalEntity{Name: "ProviderCo"}},
+					{Name: "group-svc", Version: "0.1.0", Group: "grp"},
+				},
+			},
+			expected: []*sbom.Tool{
+				{Name: "scan-svc", Version: "1.2.3", Vendor: "ProviderCo"},
+				{Name: "group-svc", Version: "0.1.0", Vendor: "grp"},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := cdxu.cdxToolsToSBOMTools(tc.sut)
+			require.Len(t, got, len(tc.expected))
+			for i := range tc.expected {
+				require.Equal(t, tc.expected[i].GetName(), got[i].GetName())
+				require.Equal(t, tc.expected[i].GetVersion(), got[i].GetVersion())
+				require.Equal(t, tc.expected[i].GetVendor(), got[i].GetVendor())
+			}
+		})
+	}
+}
+
+// TestCDXUnserializeMetadataTools exercises the full parse path (the exact
+// symptom from the issue: GetMetadata().GetTools() coming back empty) for both
+// the legacy 1.4 array and the 1.5+ component object forms.
+func TestCDXUnserializeMetadataTools(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		doc      string
+		expected []*sbom.Tool
+	}{
+		{
+			name: "cdx 1.4 legacy tools array",
+			doc: `{
+				"bomFormat": "CycloneDX",
+				"specVersion": "1.4",
+				"version": 1,
+				"metadata": {
+					"tools": [
+						{"vendor": "CycloneDX", "name": "cyclonedx-gomod", "version": "v1.4.0"}
+					]
+				}
+			}`,
+			expected: []*sbom.Tool{
+				{Name: "cyclonedx-gomod", Version: "v1.4.0", Vendor: "CycloneDX"},
+			},
+		},
+		{
+			name: "cdx 1.5 tools object with components",
+			doc: `{
+				"bomFormat": "CycloneDX",
+				"specVersion": "1.5",
+				"version": 1,
+				"metadata": {
+					"tools": {
+						"components": [
+							{"type": "application", "name": "trivy", "version": "0.50.0", "manufacturer": {"name": "Aqua Security"}}
+						]
+					}
+				}
+			}`,
+			expected: []*sbom.Tool{
+				{Name: "trivy", Version: "0.50.0", Vendor: "Aqua Security"},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cdxu := NewCDX("", cdxUnserializerTestEncoding)
+			doc, err := cdxu.Unserialize(strings.NewReader(tc.doc), nil, nil)
+			require.NoError(t, err)
+			tools := doc.GetMetadata().GetTools()
+			require.Len(t, tools, len(tc.expected))
+			for i := range tc.expected {
+				require.Equal(t, tc.expected[i].GetName(), tools[i].GetName())
+				require.Equal(t, tc.expected[i].GetVersion(), tools[i].GetVersion())
+				require.Equal(t, tc.expected[i].GetVendor(), tools[i].GetVendor())
+			}
 		})
 	}
 }


### PR DESCRIPTION
Parsing a CycloneDX SBOM, `d.GetMetadata().GetTools()` always came back empty, even when the source had a populated `metadata.tools`. The unserializer inits `md.Tools` to an empty slice and nothing downstream ever fills it, so the tool name/version/vendor just got dropped on read. This addresses #417.

The change reads `bom.Metadata.Tools` and populates the existing Tool fields for both shapes the spec allows: the legacy 1.4 array, and the 1.5+ object form with components and services. A tool component has no single vendor field, so I derive one with a publisher -> manufacturer.name -> author -> group fallback (different generators fill different fields), and services fall back to provider name then group. Everything is nil-guarded.

I've kept this deliberately minimal: it populates the fields the `Tool` message already has so consumers stop losing the data today. The richer modeling of tool components as full graph nodes (per the earlier discussion around #68) is still worth doing and can follow separately - this isn't meant to be the last word on it, just an incremental unblock. Added tests for both shapes that fail before the change and pass after.
