### PR TITLE
fix(cdx): guard nil License pointer in license choice conversion

### DIFF
--- a/pkg/native/unserializers/unserializer_cdx.go
+++ b/pkg/native/unserializers/unserializer_cdx.go
@@ -330,7 +330,7 @@ func (u *CDX) licenseChoicesToLicenseList(lcs *cdx.Licenses) []string {
 		// TODO(license): This should handle licenses without an ID and
 		// create custom licenses or another solution that captures the
 		// full custom license text.
-		if lc.Expression == "" && lc.License.ID == "" {
+		if lc.Expression == "" && (lc.License == nil || lc.License.ID == "") {
 			continue
 		}
 
@@ -358,7 +358,7 @@ func (u *CDX) licenseChoicesToLicenseString(lcs *cdx.Licenses) string {
 		// TODO(license): This should handle licenses without an ID and
 		// create custom licenses or another solution that captures the
 		// full custom license text.
-		if lc.Expression == "" && lc.License.ID == "" {
+		if lc.Expression == "" && (lc.License == nil || lc.License.ID == "") {
 			continue
 		}
 

--- a/pkg/native/unserializers/unserializer_cdx_test.go
+++ b/pkg/native/unserializers/unserializer_cdx_test.go
@@ -176,3 +176,37 @@ func TestDeterministicIds(t *testing.T) {
 		})
 	}
 }
+
+func TestLicenseChoicesNilLicense(t *testing.T) {
+	cdxu := NewCDX(cdxUnserializerTestVersion, cdxUnserializerTestEncoding)
+	for _, tc := range []struct {
+		name     string
+		licenses cdx.Licenses
+	}{
+		{
+			name:     "empty license choice",
+			licenses: cdx.Licenses{{}},
+		},
+		{
+			name:     "nil license pointer with empty expression",
+			licenses: cdx.Licenses{{License: nil, Expression: ""}},
+		},
+		{
+			name:     "nil license mixed with a real id",
+			licenses: cdx.Licenses{{}, {License: &cdx.License{ID: "MIT"}}},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// A CycloneDX document can carry a license choice with no
+			// license object at all (for example "licenses":[{}]). These
+			// helpers must not dereference the nil License pointer.
+			licenses := tc.licenses
+			require.NotPanics(t, func() {
+				cdxu.licenseChoicesToLicenseList(&licenses)
+			})
+			require.NotPanics(t, func() {
+				cdxu.licenseChoicesToLicenseString(&licenses)
+			})
+		})
+	}
+}


### PR DESCRIPTION
Feeding a CycloneDX document that has a license choice with no license object, like:

```json
"licenses": [{}]
```

(or an explicit `"license": null`) currently panics the CycloneDX unserializer with a nil pointer dereference. `cyclonedx-go` models a license choice as a struct where `License` is a `*cyclonedx.License` pointer, so an empty entry leaves that pointer nil.

Both `licenseChoicesToLicenseList` and `licenseChoicesToLicenseString` do:

```go
if lc.Expression == "" && lc.License.ID == "" {
```

When the expression is empty and `lc.License` is nil, reading `lc.License.ID` crashes. This is reachable from the public API through `reader.ParseStream`, not just internal helpers, so a single malformed SBOM can take down a caller.

The fix guards the pointer before dereferencing it in both helpers:

```go
if lc.Expression == "" && (lc.License == nil || lc.License.ID == "") {
    continue
}
```

The rest of each helper only touches `lc.License.ID` in the branch where the guard already proved the license is present, so no other change is needed. This matches how the dependency-graph code path already nil-guards the same pattern.

Added a table test in `unserializer_cdx_test.go` that runs both helpers over empty, explicitly-nil, and mixed (nil plus a real MIT id) license choices and asserts they do not panic. It fails before the guard and passes after.

Ran `go test ./pkg/native/unserializers/... ./pkg/reader/...` locally and both packages pass.